### PR TITLE
fix: guesses are now counted properly:

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/app/src/main/java/com/codenames/frontend/data/model/GameState.kt
+++ b/app/src/main/java/com/codenames/frontend/data/model/GameState.kt
@@ -10,6 +10,7 @@ data class GameState(
     val currentTurn: PlayerRoles = PlayerRoles.NONE,
     val winner: Team? = null,
     val remainingGuesses: Int = 0,
+    val numGuesses: Int = 0,
     val currentRedFound: Int = 0,
     val currentBlueFound: Int = 0,
     val chatLists: ChatLists = ChatLists(),

--- a/app/src/main/java/com/codenames/frontend/data/model/Mapper.kt
+++ b/app/src/main/java/com/codenames/frontend/data/model/Mapper.kt
@@ -33,7 +33,8 @@ fun GameMessage.toGameState(): GameState {
         cards = cards,
         currentTurn = getCurrentTurn(),
         winner = winner,
-        remainingGuesses = currentClue?.guessAmount ?: 0,
+        numGuesses = currentClue?.guessAmount ?: 0,
+        remainingGuesses = remainingGuesses,
         currentRedFound = cards.count { it.type == CardType.RED && it.revealed },
         currentBlueFound = cards.count { it.type == CardType.BLUE && it.revealed },
     )

--- a/app/src/main/java/com/codenames/frontend/network/dto/GameMessage.kt
+++ b/app/src/main/java/com/codenames/frontend/network/dto/GameMessage.kt
@@ -12,4 +12,5 @@ data class GameMessage(
     val currentClue: ClueDto? = null,
     val cardList: List<CardDto> = emptyList(),
     val error: String? = null,
+    val remainingGuesses: Int = 0
 )

--- a/app/src/main/java/com/codenames/frontend/network/dto/GameMessage.kt
+++ b/app/src/main/java/com/codenames/frontend/network/dto/GameMessage.kt
@@ -12,5 +12,5 @@ data class GameMessage(
     val currentClue: ClueDto? = null,
     val cardList: List<CardDto> = emptyList(),
     val error: String? = null,
-    val remainingGuesses: Int = 0
+    val remainingGuesses: Int = 0,
 )

--- a/app/src/main/java/com/codenames/frontend/ui/screens/GameboardScreen.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/GameboardScreen.kt
@@ -1,5 +1,6 @@
 package com.codenames.frontend.ui.screens
 
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectTransformGestures
@@ -126,6 +127,7 @@ fun GameboardScreen(
     val currentTurn = gameState.currentTurn
     val winner = gameState.winner
     val remainingGuesses = gameState.remainingGuesses
+    val numGuesses = gameState.numGuesses
     val chatLists = gameState.chatLists
     val currentRedFound = gameState.currentRedFound
     val currentBlueFound = gameState.currentBlueFound
@@ -172,6 +174,7 @@ fun GameboardScreen(
                 currentTurn = currentTurn,
                 winner = winner,
                 remainingGuesses = remainingGuesses,
+                numGuesses = numGuesses
             )
 
             ChatToggle(
@@ -478,8 +481,11 @@ fun GameStatusBar(
     currentTurn: PlayerRoles?,
     winner: Team?,
     remainingGuesses: Int,
+    numGuesses: Int
 ) {
     val dimensions = LocalResponsiveDimensions.current
+
+    Log.d("GameboardScreen", "GameStatusBar: Updated guesses. Remaining guesses: $remainingGuesses")
 
     Row(
         modifier =
@@ -492,7 +498,7 @@ fun GameStatusBar(
         val statusText =
             when {
                 winner != null -> "Winner: $winner"
-                currentTurn != null -> "Turn: ${currentTurn.name} | Guesses: $remainingGuesses"
+                currentTurn != null -> "Turn: ${currentTurn.name} | Remaining Guesses: $remainingGuesses/$numGuesses"
                 else -> "Waiting for turn..."
             }
 

--- a/app/src/main/java/com/codenames/frontend/ui/screens/GameboardScreen.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/GameboardScreen.kt
@@ -174,7 +174,7 @@ fun GameboardScreen(
                 currentTurn = currentTurn,
                 winner = winner,
                 remainingGuesses = remainingGuesses,
-                numGuesses = numGuesses
+                numGuesses = numGuesses,
             )
 
             ChatToggle(
@@ -481,7 +481,7 @@ fun GameStatusBar(
     currentTurn: PlayerRoles?,
     winner: Team?,
     remainingGuesses: Int,
-    numGuesses: Int
+    numGuesses: Int,
 ) {
     val dimensions = LocalResponsiveDimensions.current
 

--- a/app/src/main/java/com/codenames/frontend/ui/screens/LobbyScreen.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/LobbyScreen.kt
@@ -95,6 +95,20 @@ fun LobbyScreen(
                     role = role.name,
                     isHost = viewModel.getIsHost(usernameState.username),
                 )
+            }
+        }
+    }
+
+    LaunchedEffect(connectionState) {
+        val lobbyCode = lobbyUiState.lobbyCode.orEmpty()
+        val teamAndRole = currentRole.toTeamAndRole()
+
+        if (connectionState == ConnectionState.CONNECTED) {
+            navController.navigate(Screen.Gameboard.route)
+
+            if (lobbyCode.isNotBlank() && teamAndRole != null) {
+                val (team, role) = teamAndRole
+
                 chatViewModel.subscribeToChats(
                     username = usernameState.username,
                     lobbyCode = lobbyCode,
@@ -102,12 +116,6 @@ fun LobbyScreen(
                     role = role.name,
                 )
             }
-        }
-    }
-
-    LaunchedEffect(connectionState) {
-        if (connectionState == ConnectionState.CONNECTED) {
-            navController.navigate(Screen.Gameboard.route)
         }
     }
 

--- a/app/src/main/java/com/codenames/frontend/viewmodel/GameViewModel.kt
+++ b/app/src/main/java/com/codenames/frontend/viewmodel/GameViewModel.kt
@@ -186,6 +186,7 @@ class GameViewModel
 
         fun handleMessage(message: GameMessage) {
             val state = message.toGameState()
+            Log.d("GameViewModel", "New Game State: $state")
             _uiState.update {
                 state
             }

--- a/app/src/test/java/com/codenames/frontend/data/model/MapperTest.kt
+++ b/app/src/test/java/com/codenames/frontend/data/model/MapperTest.kt
@@ -80,17 +80,19 @@ class MapperTest {
                 currentTurn = Team.RED,
                 currentPhase = Role.OPERATIVE,
                 winner = null,
+                remainingGuesses = 2,
             )
 
         val result = gameMessage.toGameState()
 
         assertEquals("Animal", result.currentHint)
         assertEquals(PlayerRoles.RED_OPERATIVE, result.currentTurn)
-        assertEquals(2, result.remainingGuesses)
+        assertEquals(2, result.numGuesses)
         assertNull(result.winner)
 
         assertEquals(1, result.cards.size)
         assertEquals("Dog", result.cards[0].word)
+        assertEquals(2, result.remainingGuesses)
     }
 
     @Test

--- a/app/src/test/java/com/codenames/frontend/viewmodel/GameViewModelTest.kt
+++ b/app/src/test/java/com/codenames/frontend/viewmodel/GameViewModelTest.kt
@@ -240,7 +240,7 @@ class GameViewModelTest {
 
             assertEquals(PlayerRoles.BLUE_OPERATIVE, state.currentTurn)
             assertEquals("EAGLE", state.currentHint)
-            assertEquals(3, state.remainingGuesses)
+            assertEquals(3, state.numGuesses)
             assertEquals(2, state.cards.size)
             assertEquals("BERLIN", state.cards[0].word)
         }


### PR DESCRIPTION
# Context
There was a bug with the displayed guess count during the game. When a card was flipped, the guess would not change. This is now fixed.

# Changes in the codebase
- added remaining guesses to game state
- guesses are now displayed in format: Remaining: X/Y

# Changes outside the codebase
N/A

# Additional information
N/A