### PR TITLE
Fix/restrict guesses to active team

### DIFF
--- a/app/src/androidTest/java/com/codenames/frontend/GameboardScreenTest.kt
+++ b/app/src/androidTest/java/com/codenames/frontend/GameboardScreenTest.kt
@@ -192,6 +192,31 @@ class GameboardScreenTest {
     }
 
     @Test
+    fun inactiveOperativeCannotSelectCards() {
+        composeRule.setContent {
+            GameboardScreen(
+                userRole = PlayerRoles.BLUE_OPERATIVE,
+                gameState =
+                    GameState(
+                        currentHint = "EAGLE",
+                        currentTurn = PlayerRoles.RED_OPERATIVE,
+                        remainingGuesses = 2,
+                        cards =
+                            listOf(
+                                GameCard("BERLIN", CardType.BLUE),
+                                GameCard("ROME", CardType.RED),
+                            ),
+                    ),
+                onHintChange = { _, _ -> },
+                onReveal = {},
+            )
+        }
+
+        composeRule.onNodeWithText("BERLIN").performClick()
+        composeRule.onAllNodesWithText("Deselect all").assertCountEquals(0)
+    }
+
+    @Test
     fun clickingSelectedCardRevealsOnlyThatCard() {
         var revealedPositions = emptyList<Int>()
 

--- a/app/src/main/java/com/codenames/frontend/ui/screens/GameScreenWrapper.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/GameScreenWrapper.kt
@@ -42,7 +42,7 @@ fun GameScreenWrapper(
             gameViewModel.submitClue(lobbyCode, word, count)
         },
         onReveal = { positions ->
-            gameViewModel.submitGuesses(lobbyCode, positions)
+            gameViewModel.submitGuesses(lobbyCode, positions, team)
         },
         onSendChatMessage = { tab, message ->
             chatViewModel.sendChatMessage(

--- a/app/src/main/java/com/codenames/frontend/ui/screens/GameboardScreen.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/GameboardScreen.kt
@@ -142,7 +142,7 @@ fun GameboardScreen(
 
     val isSpymaster =
         userRole == PlayerRoles.BLUE_SPYMASTER || userRole == PlayerRoles.RED_SPYMASTER
-    val canSelectCards = !isSpymaster && remainingGuesses > 0
+    val canSelectCards = userRole == currentTurn && !isSpymaster && remainingGuesses > 0
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusManager = LocalFocusManager.current
 

--- a/app/src/main/java/com/codenames/frontend/viewmodel/GameViewModel.kt
+++ b/app/src/main/java/com/codenames/frontend/viewmodel/GameViewModel.kt
@@ -108,15 +108,14 @@ class GameViewModel
         fun submitGuess(
             lobbyCode: String,
             position: Int,
+            team: Team?,
         ) {
-            if (lobbyCode.isBlank()) {
+            if (lobbyCode.isBlank() || team == null) {
                 return
             }
 
             val turn = uiState.value.currentTurn
-            if (turn != PlayerRoles.BLUE_OPERATIVE && turn != PlayerRoles.RED_OPERATIVE) return
-
-            val team = if (turn == PlayerRoles.BLUE_OPERATIVE) Team.BLUE else Team.RED
+            if (!team.isActiveOperativeTurn(turn)) return
             viewModelScope.launch {
                 try {
                     gameRepository.submitGuess(lobbyCode, position, team)
@@ -129,15 +128,14 @@ class GameViewModel
         fun submitGuesses(
             lobbyCode: String,
             positions: List<Int>,
+            team: Team?,
         ) {
-            if (lobbyCode.isBlank() || positions.isEmpty()) {
+            if (lobbyCode.isBlank() || positions.isEmpty() || team == null) {
                 return
             }
 
             val turn = uiState.value.currentTurn
-            if (turn != PlayerRoles.BLUE_OPERATIVE && turn != PlayerRoles.RED_OPERATIVE) return
-
-            val team = if (turn == PlayerRoles.BLUE_OPERATIVE) Team.BLUE else Team.RED
+            if (!team.isActiveOperativeTurn(turn)) return
             viewModelScope.launch {
                 try {
                     positions.forEach { position ->
@@ -148,6 +146,10 @@ class GameViewModel
                 }
             }
         }
+
+        private fun Team.isActiveOperativeTurn(turn: PlayerRoles): Boolean =
+            (this == Team.BLUE && turn == PlayerRoles.BLUE_OPERATIVE) ||
+                (this == Team.RED && turn == PlayerRoles.RED_OPERATIVE)
 
         fun handleMessage(message: GameMessage) {
             val state = message.toGameState()

--- a/app/src/test/java/com/codenames/frontend/viewmodel/GameViewModelTest.kt
+++ b/app/src/test/java/com/codenames/frontend/viewmodel/GameViewModelTest.kt
@@ -296,7 +296,7 @@ class GameViewModelTest {
 
             viewModel.handleMessage(testMessage.copy(currentTurn = Team.RED, currentPhase = Role.OPERATIVE))
 
-            viewModel.submitGuess(lobbyCode, 3)
+            viewModel.submitGuess(lobbyCode, 3, Team.RED)
             advanceUntilIdle()
 
             coVerify { gameRepository.submitGuess(lobbyCode, 3, Team.RED) }
@@ -307,7 +307,7 @@ class GameViewModelTest {
         runTest {
             viewModel.handleMessage(testMessage.copy(currentTurn = Team.RED, currentPhase = Role.SPYMASTER))
 
-            viewModel.submitGuess(lobbyCode, 3)
+            viewModel.submitGuess(lobbyCode, 3, Team.RED)
             advanceUntilIdle()
 
             coVerify(exactly = 0) {
@@ -320,7 +320,7 @@ class GameViewModelTest {
         runTest {
             viewModel.handleMessage(testMessage.copy(currentTurn = Team.RED, currentPhase = Role.OPERATIVE))
 
-            viewModel.submitGuess("", 3)
+            viewModel.submitGuess("", 3, Team.RED)
             advanceUntilIdle()
 
             coVerify(exactly = 0) {
@@ -337,7 +337,7 @@ class GameViewModelTest {
 
             viewModel.handleMessage(testMessage.copy(currentTurn = Team.RED, currentPhase = Role.OPERATIVE))
 
-            viewModel.submitGuess(lobbyCode, 3)
+            viewModel.submitGuess(lobbyCode, 3, Team.RED)
             advanceUntilIdle()
 
             val state = viewModel.connectionState.value
@@ -353,7 +353,7 @@ class GameViewModelTest {
 
             viewModel.handleMessage(testMessage.copy(currentTurn = Team.RED, currentPhase = Role.OPERATIVE))
 
-            viewModel.submitGuesses(lobbyCode, listOf(2, 4))
+            viewModel.submitGuesses(lobbyCode, listOf(2, 4), Team.RED)
             advanceUntilIdle()
 
             coVerify {
@@ -371,7 +371,7 @@ class GameViewModelTest {
 
             viewModel.handleMessage(testMessage.copy(currentTurn = Team.BLUE, currentPhase = Role.OPERATIVE))
 
-            viewModel.submitGuesses(lobbyCode, listOf(1))
+            viewModel.submitGuesses(lobbyCode, listOf(1), Team.BLUE)
             advanceUntilIdle()
 
             coVerify {
@@ -384,7 +384,33 @@ class GameViewModelTest {
         runTest {
             viewModel.handleMessage(testMessage.copy(currentTurn = Team.RED, currentPhase = Role.OPERATIVE))
 
-            viewModel.submitGuesses(lobbyCode, emptyList())
+            viewModel.submitGuesses(lobbyCode, emptyList(), Team.RED)
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) {
+                gameRepository.submitGuess(any(), any(), any())
+            }
+        }
+
+    @Test
+    fun submitGuesses_blankLobbyCode_doesNotSendGuess() =
+        runTest {
+            viewModel.handleMessage(testMessage.copy(currentTurn = Team.RED, currentPhase = Role.OPERATIVE))
+
+            viewModel.submitGuesses("", listOf(3), Team.RED)
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) {
+                gameRepository.submitGuess(any(), any(), any())
+            }
+        }
+
+    @Test
+    fun submitGuesses_nullTeam_doesNotSendGuess() =
+        runTest {
+            viewModel.handleMessage(testMessage.copy(currentTurn = Team.RED, currentPhase = Role.OPERATIVE))
+
+            viewModel.submitGuesses(lobbyCode, listOf(3), null)
             advanceUntilIdle()
 
             coVerify(exactly = 0) {
@@ -397,11 +423,40 @@ class GameViewModelTest {
         runTest {
             viewModel.handleMessage(testMessage.copy(currentTurn = Team.RED, currentPhase = Role.SPYMASTER))
 
-            viewModel.submitGuesses(lobbyCode, listOf(3))
+            viewModel.submitGuesses(lobbyCode, listOf(3), Team.RED)
             advanceUntilIdle()
 
             coVerify(exactly = 0) {
                 gameRepository.submitGuess(any(), any(), any())
             }
+        }
+
+    @Test
+    fun submitGuesses_wrongTeamForCurrentTurn_doesNotSendGuess() =
+        runTest {
+            viewModel.handleMessage(testMessage.copy(currentTurn = Team.RED, currentPhase = Role.OPERATIVE))
+
+            viewModel.submitGuesses(lobbyCode, listOf(3), Team.BLUE)
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) {
+                gameRepository.submitGuess(any(), any(), any())
+            }
+        }
+
+    @Test
+    fun submitGuesses_networkError_updatesConnectionState() =
+        runTest {
+            coEvery {
+                gameRepository.submitGuess(any(), any(), any())
+            } throws Exception("Network connection failed")
+
+            viewModel.handleMessage(testMessage.copy(currentTurn = Team.RED, currentPhase = Role.OPERATIVE))
+
+            viewModel.submitGuesses(lobbyCode, listOf(3), Team.RED)
+            advanceUntilIdle()
+
+            val state = viewModel.connectionState.value
+            assertTrue(state is ConnectionState.Error)
         }
 }


### PR DESCRIPTION
## Context  
This PR fixes the frontend guess permission flow so only the active operative team can select cards and submit guesses.

## Description  
Operatives can now only select cards when their own team is currently in the operative guessing phase. The guess submission flow now uses the current player’s actual team from the lobby state instead of deriving the team from the current turn.

This prevents players from the inactive team from selecting cards or sending guesses as the active team.

## Changes in the code base  
Restrict card selection to the active operative team  
Pass the current player team into guess submission  
Validate guess submission against the active operative turn  
Prevent null-team, wrong-team, spymaster-phase, blank-lobby, and empty-position guess submissions  
Add ViewModel tests for active-team guess validation and error handling  
Add UI test coverage for inactive operatives not being able to select cards

## Changes outside the code base  
N/A

## Additional information  
N/A