### PR TITLE
Fix/restrict clues to active spymaster

### DIFF
--- a/app/src/androidTest/java/com/codenames/frontend/GameboardScreenTest.kt
+++ b/app/src/androidTest/java/com/codenames/frontend/GameboardScreenTest.kt
@@ -76,6 +76,25 @@ class GameboardScreenTest {
     }
 
     @Test
+    fun inactiveSpymasterCannotEnterClue() {
+        composeRule.setContent {
+            GameboardScreen(
+                userRole = PlayerRoles.BLUE_SPYMASTER,
+                gameState =
+                    GameState(
+                        currentHint = "",
+                        currentTurn = PlayerRoles.RED_SPYMASTER,
+                        cards = listOf(GameCard("BERLIN", CardType.BLUE)),
+                    ),
+                onHintChange = { _, _ -> },
+                onReveal = {},
+            )
+        }
+
+        composeRule.onAllNodesWithText("SEND").assertCountEquals(0)
+    }
+
+    @Test
     fun spymasterCanOpenLobbyChat() {
         composeRule.setContent {
             GameboardScreen(

--- a/app/src/main/java/com/codenames/frontend/ui/screens/GameScreenWrapper.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/GameScreenWrapper.kt
@@ -39,7 +39,7 @@ fun GameScreenWrapper(
                 availableChatTabs = availableChatTabs,
             ),
         onHintChange = { word, count ->
-            gameViewModel.submitClue(lobbyCode, word, count)
+            gameViewModel.submitClue(lobbyCode, word, count, team)
         },
         onReveal = { positions ->
             gameViewModel.submitGuesses(lobbyCode, positions, team)

--- a/app/src/main/java/com/codenames/frontend/ui/screens/GameboardScreen.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/GameboardScreen.kt
@@ -142,6 +142,7 @@ fun GameboardScreen(
 
     val isSpymaster =
         userRole == PlayerRoles.BLUE_SPYMASTER || userRole == PlayerRoles.RED_SPYMASTER
+    val isActiveSpymaster = userRole == currentTurn && isSpymaster
     val canSelectCards = userRole == currentTurn && !isSpymaster && remainingGuesses > 0
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusManager = LocalFocusManager.current
@@ -218,7 +219,7 @@ fun GameboardScreen(
             )
 
             HintSection(
-                isSpymaster,
+                isActiveSpymaster,
                 currentHint,
                 hintInput,
                 countInput,

--- a/app/src/main/java/com/codenames/frontend/ui/screens/LobbyScreen.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/LobbyScreen.kt
@@ -86,13 +86,8 @@ fun LobbyScreen(
             Log.d("LobbyScreen", "Lobby UI state is started, recomposing")
 
             if (lobbyCode.isNotBlank() && teamAndRole != null) {
-                val (team, role) = teamAndRole
-
                 gameViewModel.connect(
-                    username = usernameState.username,
                     lobbyCode = lobbyCode,
-                    team = team.name,
-                    role = role.name,
                     isHost = viewModel.getIsHost(usernameState.username),
                 )
             }

--- a/app/src/main/java/com/codenames/frontend/viewmodel/GameViewModel.kt
+++ b/app/src/main/java/com/codenames/frontend/viewmodel/GameViewModel.kt
@@ -37,10 +37,7 @@ class GameViewModel
         val connectionState: StateFlow<ConnectionState> = _connectionState
 
         fun connect(
-            username: String,
             lobbyCode: String,
-            team: String,
-            role: String,
             isHost: Boolean = false,
         ) {
             job?.cancel()

--- a/app/src/main/java/com/codenames/frontend/viewmodel/GameViewModel.kt
+++ b/app/src/main/java/com/codenames/frontend/viewmodel/GameViewModel.kt
@@ -87,15 +87,14 @@ class GameViewModel
             lobbyCode: String,
             word: String,
             count: Int,
+            team: Team?,
         ) {
-            if (lobbyCode.isBlank()) {
+            if (lobbyCode.isBlank() || team == null) {
                 return
             }
 
             val turn = uiState.value.currentTurn
-            if (turn != PlayerRoles.BLUE_SPYMASTER && turn != PlayerRoles.RED_SPYMASTER) return
-
-            val team = if (turn == PlayerRoles.BLUE_SPYMASTER) Team.BLUE else Team.RED
+            if (!team.isActiveSpymasterTurn(turn)) return
             viewModelScope.launch {
                 try {
                     gameRepository.submitClue(lobbyCode, word, count, team)
@@ -150,6 +149,10 @@ class GameViewModel
         private fun Team.isActiveOperativeTurn(turn: PlayerRoles): Boolean =
             (this == Team.BLUE && turn == PlayerRoles.BLUE_OPERATIVE) ||
                 (this == Team.RED && turn == PlayerRoles.RED_OPERATIVE)
+
+        private fun Team.isActiveSpymasterTurn(turn: PlayerRoles): Boolean =
+            (this == Team.BLUE && turn == PlayerRoles.BLUE_SPYMASTER) ||
+                (this == Team.RED && turn == PlayerRoles.RED_SPYMASTER)
 
         fun handleMessage(message: GameMessage) {
             val state = message.toGameState()

--- a/app/src/test/java/com/codenames/frontend/viewmodel/GameViewModelTest.kt
+++ b/app/src/test/java/com/codenames/frontend/viewmodel/GameViewModelTest.kt
@@ -245,7 +245,7 @@ class GameViewModelTest {
 
             viewModel.handleMessage(testMessage.copy(currentTurn = Team.RED, currentPhase = Role.SPYMASTER))
 
-            viewModel.submitClue(lobbyCode, "EAGLE", 2)
+            viewModel.submitClue(lobbyCode, "EAGLE", 2, Team.RED)
             advanceUntilIdle()
 
             coVerify { gameRepository.submitClue(lobbyCode, "EAGLE", 2, Team.RED) }
@@ -260,7 +260,7 @@ class GameViewModelTest {
 
             viewModel.handleMessage(testMessage.copy(currentTurn = Team.RED, currentPhase = Role.SPYMASTER))
 
-            viewModel.submitClue(lobbyCode, "EAGLE", 2)
+            viewModel.submitClue(lobbyCode, "EAGLE", 2, Team.RED)
             advanceUntilIdle()
 
             val state = viewModel.connectionState.value
@@ -270,7 +270,7 @@ class GameViewModelTest {
     @Test
     fun testSubmitClue_whenTurnIsNone_doesNotSendClue() =
         runTest {
-            viewModel.submitClue(lobbyCode, "EAGLE", 2)
+            viewModel.submitClue(lobbyCode, "EAGLE", 2, Team.RED)
             advanceUntilIdle()
             coVerify(exactly = 0) { gameRepository.submitClue(any(), any(), any(), any()) }
         }
@@ -280,8 +280,34 @@ class GameViewModelTest {
         runTest {
             viewModel.handleMessage(testMessage.copy(currentTurn = Team.RED, currentPhase = Role.SPYMASTER))
 
-            viewModel.submitClue("", "EAGLE", 2)
+            viewModel.submitClue("", "EAGLE", 2, Team.RED)
             advanceUntilIdle()
+            coVerify(exactly = 0) {
+                gameRepository.submitClue(any(), any(), any(), any())
+            }
+        }
+
+    @Test
+    fun testSubmitClue_nullTeam_doesNotSendClue() =
+        runTest {
+            viewModel.handleMessage(testMessage.copy(currentTurn = Team.RED, currentPhase = Role.SPYMASTER))
+
+            viewModel.submitClue(lobbyCode, "EAGLE", 2, null)
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) {
+                gameRepository.submitClue(any(), any(), any(), any())
+            }
+        }
+
+    @Test
+    fun testSubmitClue_wrongTeamForCurrentTurn_doesNotSendClue() =
+        runTest {
+            viewModel.handleMessage(testMessage.copy(currentTurn = Team.RED, currentPhase = Role.SPYMASTER))
+
+            viewModel.submitClue(lobbyCode, "EAGLE", 2, Team.BLUE)
+            advanceUntilIdle()
+
             coVerify(exactly = 0) {
                 gameRepository.submitClue(any(), any(), any(), any())
             }

--- a/app/src/test/java/com/codenames/frontend/viewmodel/GameViewModelTest.kt
+++ b/app/src/test/java/com/codenames/frontend/viewmodel/GameViewModelTest.kt
@@ -39,10 +39,6 @@ class GameViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
 
     private val lobbyCode = "12345"
-    private val username = "user"
-    private val team = Team.RED.name
-    private val role = Role.OPERATIVE.name
-
     private val testState =
         GameState(
             currentHint = "",
@@ -90,7 +86,7 @@ class GameViewModelTest {
             coEvery { client.connectStomp() } just Runs
             coEvery { client.subscribeToLobby(lobbyCode) } returns flow
 
-            viewModel.connect(username, lobbyCode, team, role)
+            viewModel.connect(lobbyCode)
 
             advanceUntilIdle()
 
@@ -108,11 +104,11 @@ class GameViewModelTest {
             coEvery { client.connectStomp() } just Runs
             coEvery { client.subscribeToLobby(lobbyCode) } returns flow
 
-            viewModel.connect(username, lobbyCode, team, role)
+            viewModel.connect(lobbyCode)
 
             advanceUntilIdle()
 
-            viewModel.connect(username, lobbyCode, team, role)
+            viewModel.connect(lobbyCode)
 
             coVerify { client.connectStomp() }
             coVerify { client.subscribeToLobby(lobbyCode) }
@@ -156,7 +152,7 @@ class GameViewModelTest {
                 client.connectStomp()
             } throws RuntimeException("Connection failed")
 
-            viewModel.connect(username, lobbyCode, team, role)
+            viewModel.connect(lobbyCode)
 
             advanceUntilIdle()
 
@@ -181,10 +177,7 @@ class GameViewModelTest {
             } just Runs
 
             viewModel.connect(
-                username,
                 lobbyCode,
-                team,
-                role,
                 isHost = true,
             )
 
@@ -202,10 +195,7 @@ class GameViewModelTest {
             coEvery { client.subscribeToLobby(any()) } returns emptyFlow()
 
             viewModel.connect(
-                username,
                 "",
-                team,
-                role,
                 isHost = true,
             )
 


### PR DESCRIPTION
## Context
This PR fixes the frontend clue submission flow so only the active team’s spymaster can enter and send clues.

## Description
Spymasters can now only access the clue input when their own team is currently in the spymaster phase. The inactive spymaster still sees the current clue like other players, but cannot enter or submit a new clue.

The clue submission flow now uses the current player’s actual team from the lobby state instead of deriving the team from the current turn. This prevents a spymaster from the wrong team from submitting a clue as the active team through the normal frontend flow.

## Changes in the code base
Restrict clue input visibility to the active spymaster
Show the current clue to inactive spymasters instead of the clue input
Pass the current player team into clue submission
Validate clue submission against the active spymaster turn
Add ViewModel tests for active-spymaster clue validation and error handling
Add UI test coverage for inactive spymasters not being able to enter clues
Remove unused game connection parameters from the frontend ViewModel flow

Changes outside the code base
N/A

Additional information
N/A

<img width="759" height="358" alt="Screenshot 2026-06-12 at 12 55 51" src="https://github.com/user-attachments/assets/7d427097-f725-4b44-b69c-3f6312a21042" />
<img width="776" height="366" alt="Screenshot 2026-06-12 at 12 56 41" src="https://github.com/user-attachments/assets/ca3e846d-c90f-4fb6-8d41-b053c295df59" />
