### PR TITLE
Feature/pass turn

### DIFF
--- a/app/src/androidTest/java/com/codenames/frontend/GameboardScreenTest.kt
+++ b/app/src/androidTest/java/com/codenames/frontend/GameboardScreenTest.kt
@@ -236,6 +236,93 @@ class GameboardScreenTest {
     }
 
     @Test
+    fun activeOperativeSeesEndTurnButton() {
+        composeRule.setContent {
+            GameboardScreen(
+                userRole = PlayerRoles.BLUE_OPERATIVE,
+                gameState =
+                    GameState(
+                        currentHint = "EAGLE",
+                        currentTurn = PlayerRoles.BLUE_OPERATIVE,
+                        remainingGuesses = 2,
+                        cards = listOf(GameCard("BERLIN", CardType.BLUE)),
+                    ),
+                onHintChange = { _, _ -> },
+                onReveal = {},
+            )
+        }
+
+        composeRule.onNodeWithText("End Turn").assertIsDisplayed()
+    }
+
+    @Test
+    fun spymasterDoesNotSeeEndTurnButton() {
+        composeRule.setContent {
+            GameboardScreen(
+                userRole = PlayerRoles.BLUE_SPYMASTER,
+                gameState =
+                    GameState(
+                        currentHint = "EAGLE",
+                        currentTurn = PlayerRoles.BLUE_OPERATIVE,
+                        remainingGuesses = 2,
+                        cards = listOf(GameCard("BERLIN", CardType.BLUE)),
+                    ),
+                onHintChange = { _, _ -> },
+                onReveal = {},
+            )
+        }
+
+        composeRule.onAllNodesWithText("End Turn").assertCountEquals(0)
+    }
+
+    @Test
+    fun inactiveOperativeDoesNotSeeEndTurnButton() {
+        composeRule.setContent {
+            GameboardScreen(
+                userRole = PlayerRoles.RED_OPERATIVE,
+                gameState =
+                    GameState(
+                        currentHint = "EAGLE",
+                        currentTurn = PlayerRoles.BLUE_OPERATIVE,
+                        remainingGuesses = 2,
+                        cards = listOf(GameCard("BERLIN", CardType.BLUE)),
+                    ),
+                onHintChange = { _, _ -> },
+                onReveal = {},
+            )
+        }
+
+        composeRule.onAllNodesWithText("End Turn").assertCountEquals(0)
+    }
+
+    @Test
+    fun endTurnButtonCallsPassTurn() {
+        var passTurnClicks = 0
+
+        composeRule.setContent {
+            GameboardScreen(
+                userRole = PlayerRoles.BLUE_OPERATIVE,
+                gameState =
+                    GameState(
+                        currentHint = "EAGLE",
+                        currentTurn = PlayerRoles.BLUE_OPERATIVE,
+                        remainingGuesses = 2,
+                        cards = listOf(GameCard("BERLIN", CardType.BLUE)),
+                    ),
+                onHintChange = { _, _ -> },
+                onReveal = {},
+                onPassTurn = { passTurnClicks++ },
+            )
+        }
+
+        composeRule.onNodeWithText("End Turn").performClick()
+
+        composeRule.runOnIdle {
+            assertEquals(1, passTurnClicks)
+        }
+    }
+
+    @Test
     fun clickingSelectedCardRevealsOnlyThatCard() {
         var revealedPositions = emptyList<Int>()
 

--- a/app/src/main/java/com/codenames/frontend/data/repository/GameRepository.kt
+++ b/app/src/main/java/com/codenames/frontend/data/repository/GameRepository.kt
@@ -47,7 +47,7 @@ class GameRepository
                     lobbyCode = lobbyCode,
                     position = position,
                     currentTurn = currentTurn,
-            )
+                )
             webSocketHandler.sendGuess(msg)
         }
 

--- a/app/src/main/java/com/codenames/frontend/data/repository/GameRepository.kt
+++ b/app/src/main/java/com/codenames/frontend/data/repository/GameRepository.kt
@@ -4,6 +4,7 @@ import com.codenames.frontend.data.model.enums.Role
 import com.codenames.frontend.data.model.enums.Team
 import com.codenames.frontend.network.dto.ClueMessageDto
 import com.codenames.frontend.network.dto.GuessMessage
+import com.codenames.frontend.network.dto.PassTurnMessage
 import com.codenames.frontend.network.dto.StartGameMessage
 import com.codenames.frontend.network.dto.WebSocketJoinMessage
 import com.codenames.frontend.network.websocket.GameWebSocketController
@@ -46,8 +47,20 @@ class GameRepository
                     lobbyCode = lobbyCode,
                     position = position,
                     currentTurn = currentTurn,
-                )
+            )
             webSocketHandler.sendGuess(msg)
+        }
+
+        suspend fun passTurn(
+            lobbyCode: String,
+            currentTurn: Team,
+        ) {
+            val msg =
+                PassTurnMessage(
+                    lobbyCode = lobbyCode,
+                    currentTurn = currentTurn,
+                )
+            webSocketHandler.passTurn(msg)
         }
 
         suspend fun sendRejoin(

--- a/app/src/main/java/com/codenames/frontend/network/dto/PassTurnMessage.kt
+++ b/app/src/main/java/com/codenames/frontend/network/dto/PassTurnMessage.kt
@@ -1,0 +1,10 @@
+package com.codenames.frontend.network.dto
+
+import com.codenames.frontend.data.model.enums.Team
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PassTurnMessage(
+    val lobbyCode: String,
+    val currentTurn: Team,
+)

--- a/app/src/main/java/com/codenames/frontend/network/websocket/GameWebSocketController.kt
+++ b/app/src/main/java/com/codenames/frontend/network/websocket/GameWebSocketController.kt
@@ -3,6 +3,7 @@ package com.codenames.frontend.network.websocket
 import com.codenames.frontend.network.dto.ClueMessageDto
 import com.codenames.frontend.network.dto.GameMessage
 import com.codenames.frontend.network.dto.GuessMessage
+import com.codenames.frontend.network.dto.PassTurnMessage
 import com.codenames.frontend.network.dto.StartGameMessage
 import com.codenames.frontend.network.dto.WebSocketJoinMessage
 import kotlinx.coroutines.flow.Flow
@@ -39,5 +40,9 @@ class GameWebSocketController
 
         suspend fun sendGuess(msg: GuessMessage) {
             webSocketSessionManager.getSession().convertAndSend("/app/reveal-card", msg, GuessMessage.serializer())
+        }
+
+        suspend fun passTurn(msg: PassTurnMessage) {
+            webSocketSessionManager.getSession().convertAndSend("/app/pass-turn", msg, PassTurnMessage.serializer())
         }
     }

--- a/app/src/main/java/com/codenames/frontend/ui/buttons/SettingsCornerButton.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/buttons/SettingsCornerButton.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
 import com.codenames.frontend.ui.theme.AppInk
@@ -27,7 +28,7 @@ fun BoxScope.SettingsCornerButton(onClick: () -> Unit) {
         modifier =
             Modifier
                 .align(Alignment.TopEnd)
-                .padding(top = dimensions.smallSpacing, end = dimensions.smallSpacing)
+                .padding(top = 0.dp, end = dimensions.smallSpacing)
                 .width(dimensions.cornerButtonSize)
                 .height(dimensions.cornerButtonSize)
                 .zIndex(1f),

--- a/app/src/main/java/com/codenames/frontend/ui/screens/GameScreenWrapper.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/GameScreenWrapper.kt
@@ -52,6 +52,9 @@ fun GameScreenWrapper(
         onReveal = { positions ->
             gameViewModel.submitGuesses(lobbyCode, positions, team)
         },
+        onPassTurn = {
+            gameViewModel.passTurn(lobbyCode, team)
+        },
         onSendChatMessage = { tab, message ->
             chatViewModel.sendChatMessage(
                 tab = tab,

--- a/app/src/main/java/com/codenames/frontend/ui/screens/GameboardScreen.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/GameboardScreen.kt
@@ -121,6 +121,7 @@ fun GameboardScreen(
     onHintChange: (String, Int) -> Unit,
     onReveal: (List<Int>) -> Unit,
     modifier: Modifier = Modifier,
+    onPassTurn: () -> Unit = {},
     onSendChatMessage: (ChatTab, String) -> Unit = { _, _ -> },
     onSettingsClick: (() -> Unit)? = null,
 ) {
@@ -147,7 +148,8 @@ fun GameboardScreen(
     val isSpymaster =
         userRole == PlayerRoles.BLUE_SPYMASTER || userRole == PlayerRoles.RED_SPYMASTER
     val isActiveSpymaster = userRole == currentTurn && isSpymaster
-    val canSelectCards = userRole == currentTurn && !isSpymaster && remainingGuesses > 0
+    val canEndTurn = userRole == currentTurn && !isSpymaster && remainingGuesses > 0
+    val canSelectCards = canEndTurn
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusManager = LocalFocusManager.current
 
@@ -187,11 +189,23 @@ fun GameboardScreen(
                 numGuesses = numGuesses,
             )
 
-            ChatToggle(
-                isVisible = availableChatTabs.isNotEmpty(),
-                isChatOpen = isChatOpen,
-                onClick = { isChatOpen = !isChatOpen },
-            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                ChatToggle(
+                    isVisible = availableChatTabs.isNotEmpty(),
+                    isChatOpen = isChatOpen,
+                    onClick = { isChatOpen = !isChatOpen },
+                )
+
+                EndTurnButton(
+                    isVisible = canEndTurn,
+                    onClick = onPassTurn,
+                    modifier = Modifier.width(140.dp),
+                )
+            }
 
             Spacer(modifier = Modifier.height(dimensions.gameBoardTopSpacing))
 
@@ -443,6 +457,32 @@ private fun DeselectAllButton(
             modifier =
                 modifier
                     .fillMaxWidth()
+                    .height(dimensions.secondaryButtonHeight),
+            style =
+                AppButtonStyle(
+                    containerColor = AppGreen,
+                    contentColor = AppWhite,
+                    fontSize = dimensions.bodyFontSize,
+                ),
+        )
+    }
+}
+
+@Suppress("ktlint:standard:function-naming")
+@Composable
+private fun EndTurnButton(
+    isVisible: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val dimensions = LocalResponsiveDimensions.current
+
+    if (isVisible) {
+        AppButton(
+            text = "End Turn",
+            onClick = onClick,
+            modifier =
+                modifier
                     .height(dimensions.secondaryButtonHeight),
             style =
                 AppButtonStyle(

--- a/app/src/main/java/com/codenames/frontend/viewmodel/GameViewModel.kt
+++ b/app/src/main/java/com/codenames/frontend/viewmodel/GameViewModel.kt
@@ -146,6 +146,25 @@ class GameViewModel
             }
         }
 
+        fun passTurn(
+            lobbyCode: String,
+            team: Team?,
+        ) {
+            if (lobbyCode.isBlank() || team == null) {
+                return
+            }
+
+            val turn = uiState.value.currentTurn
+            if (!team.isActiveOperativeTurn(turn)) return
+            viewModelScope.launch {
+                try {
+                    gameRepository.passTurn(lobbyCode, team)
+                } catch (e: Exception) {
+                    _connectionState.value = ConnectionState.Error(e.message ?: CONNECTION_ERROR_MESSAGE)
+                }
+            }
+        }
+
         fun rejoinGame(
             username: String,
             userId: UUID,

--- a/app/src/test/java/com/codenames/frontend/data/repository/GameRepositoryTest.kt
+++ b/app/src/test/java/com/codenames/frontend/data/repository/GameRepositoryTest.kt
@@ -61,4 +61,17 @@ class GameRepositoryTest {
 
             coVerify { webSocketHandler.sendGuess(any()) }
         }
+
+    @Test
+    fun testPassTurn() =
+        runTest {
+            val lobbyCode = "ABCDE"
+            val currentTurn = Team.RED
+
+            coEvery { webSocketHandler.passTurn(any()) } just Runs
+
+            gameRepository.passTurn(lobbyCode, currentTurn)
+
+            coVerify { webSocketHandler.passTurn(any()) }
+        }
 }

--- a/app/src/test/java/com/codenames/frontend/network/websocket/GameWebSocketControllerTest.kt
+++ b/app/src/test/java/com/codenames/frontend/network/websocket/GameWebSocketControllerTest.kt
@@ -4,6 +4,7 @@ import com.codenames.frontend.data.model.enums.Team
 import com.codenames.frontend.network.dto.ClueMessageDto
 import com.codenames.frontend.network.dto.GameMessage
 import com.codenames.frontend.network.dto.GuessMessage
+import com.codenames.frontend.network.dto.PassTurnMessage
 import com.codenames.frontend.network.dto.StartGameMessage
 import com.codenames.frontend.network.dto.WebSocketJoinMessage
 import io.mockk.coEvery
@@ -122,6 +123,22 @@ class GameWebSocketControllerTest {
                     "/app/reveal-card",
                     guessMessage,
                     GuessMessage.serializer(),
+                )
+            }
+        }
+
+    @Test
+    fun testPassTurn() =
+        runTest {
+            val passTurnMessage = PassTurnMessage("LOBBY123", Team.RED)
+
+            wsClient.passTurn(passTurnMessage)
+
+            coVerify {
+                session.convertAndSend(
+                    "/app/pass-turn",
+                    passTurnMessage,
+                    PassTurnMessage.serializer(),
                 )
             }
         }

--- a/app/src/test/java/com/codenames/frontend/viewmodel/GameViewModelTest.kt
+++ b/app/src/test/java/com/codenames/frontend/viewmodel/GameViewModelTest.kt
@@ -480,6 +480,91 @@ class GameViewModelTest {
         }
 
     @Test
+    fun passTurn_redOperative_sendsPassTurn() =
+        runTest {
+            coEvery {
+                gameRepository.passTurn(any(), any())
+            } just Runs
+
+            viewModel.handleMessage(testMessage.copy(currentTurn = Team.RED, currentPhase = Role.OPERATIVE))
+
+            viewModel.passTurn(lobbyCode, Team.RED)
+            advanceUntilIdle()
+
+            coVerify {
+                gameRepository.passTurn(lobbyCode, Team.RED)
+            }
+        }
+
+    @Test
+    fun passTurn_blankLobbyCode_doesNotSendPassTurn() =
+        runTest {
+            viewModel.handleMessage(testMessage.copy(currentTurn = Team.RED, currentPhase = Role.OPERATIVE))
+
+            viewModel.passTurn("", Team.RED)
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) {
+                gameRepository.passTurn(any(), any())
+            }
+        }
+
+    @Test
+    fun passTurn_nullTeam_doesNotSendPassTurn() =
+        runTest {
+            viewModel.handleMessage(testMessage.copy(currentTurn = Team.RED, currentPhase = Role.OPERATIVE))
+
+            viewModel.passTurn(lobbyCode, null)
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) {
+                gameRepository.passTurn(any(), any())
+            }
+        }
+
+    @Test
+    fun passTurn_whenTurnIsSpymaster_doesNotSendPassTurn() =
+        runTest {
+            viewModel.handleMessage(testMessage.copy(currentTurn = Team.RED, currentPhase = Role.SPYMASTER))
+
+            viewModel.passTurn(lobbyCode, Team.RED)
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) {
+                gameRepository.passTurn(any(), any())
+            }
+        }
+
+    @Test
+    fun passTurn_wrongTeamForCurrentTurn_doesNotSendPassTurn() =
+        runTest {
+            viewModel.handleMessage(testMessage.copy(currentTurn = Team.RED, currentPhase = Role.OPERATIVE))
+
+            viewModel.passTurn(lobbyCode, Team.BLUE)
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) {
+                gameRepository.passTurn(any(), any())
+            }
+        }
+
+    @Test
+    fun passTurn_networkError_updatesConnectionState() =
+        runTest {
+            coEvery {
+                gameRepository.passTurn(any(), any())
+            } throws Exception("Network connection failed")
+
+            viewModel.handleMessage(testMessage.copy(currentTurn = Team.RED, currentPhase = Role.OPERATIVE))
+
+            viewModel.passTurn(lobbyCode, Team.RED)
+            advanceUntilIdle()
+
+            val state = viewModel.connectionState.value
+            assertTrue(state is ConnectionState.Error)
+        }
+
+    @Test
     fun testSendRejoinMessage_sendsMessage() =
         runTest {
             coEvery {


### PR DESCRIPTION
## Context
This PR adds frontend support for ending the guessing phase early through the existing backend pass-turn flow.

## Description
Operatives can now end their turn without using all remaining guesses. During the active operative guessing phase, an End Turn button is shown. Clicking it sends a pass-turn message to the backend, allowing the next team to continue.

The button is only available for the operative team whose turn it currently is, so spymasters and the inactive team cannot trigger the action from the UI.

## Changes in the code base
Add pass-turn message DTO
Add websocket call for /app/pass-turn
Add repository method for passing the turn
Add ViewModel action with active-operative validation
Add End Turn button to the game board
Adjust settings button position to avoid UI overlap
Add unit tests for websocket, repository, and ViewModel pass-turn handling
Add UI tests for End Turn visibility and click behavior

## Changes outside the code base
N/A

## Additional information
The frontend uses the backend naming pass turn internally, while the UI labels the action as End Turn for clearer player-facing wording.

<img width="1600" height="720" alt="PHOTO-2026-06-14-17-06-42" src="https://github.com/user-attachments/assets/63111354-4634-4520-899f-d03d4570a55d" />
