### PR TITLE
Feature/64 improved error messages

### DIFF
--- a/app/src/main/java/com/codenames/frontend/data/error/ErrorMessageMapper.kt
+++ b/app/src/main/java/com/codenames/frontend/data/error/ErrorMessageMapper.kt
@@ -1,0 +1,47 @@
+package com.codenames.frontend.data.error
+
+import com.codenames.frontend.network.dto.LobbyResponse
+import kotlinx.serialization.json.Json
+import retrofit2.HttpException
+import java.io.IOException
+
+object ErrorMessageMapper {
+    private val json =
+        Json {
+            ignoreUnknownKeys = true
+        }
+
+    fun toUserMessage(error: Throwable): String {
+        if (error is HttpException) {
+            val backendMessage =
+                error
+                    .response()
+                    ?.errorBody()
+                    ?.string()
+                    ?.let { body ->
+                        runCatching {
+                            json.decodeFromString<LobbyResponse>(body).message
+                        }.getOrNull()
+                    }
+
+            if (!backendMessage.isNullOrBlank()) {
+                return backendMessage
+            }
+
+            return when (error.code()) {
+                400 -> "The request could not be processed. Please check your input."
+                404 -> "The requested lobby could not be found."
+                500 -> "The server has a problem right now. Please try again later."
+                else -> "Something went wrong. Please try again."
+            }
+        }
+
+        if (error is IOException) {
+            return "Could not connect to the server. Please check your connection."
+        }
+
+        return error.message
+            ?.takeIf { it.isNotBlank() }
+            ?: "Something went wrong. Please try again."
+    }
+}

--- a/app/src/main/java/com/codenames/frontend/data/model/Mapper.kt
+++ b/app/src/main/java/com/codenames/frontend/data/model/Mapper.kt
@@ -12,7 +12,7 @@ import com.codenames.frontend.ui.roles.PlayerRoles
 fun LobbyResponse.toLobbyState(): LobbyUiState =
     LobbyUiState(
         lobbyCode = lobbyCode,
-        players = playerList.map { it.toUi() },
+        players = playerList.orEmpty().map { it.toUi() },
         isGameStarted = isStarted,
     )
 
@@ -52,6 +52,9 @@ fun GameMessage.getCurrentTurn(): PlayerRoles {
         if (currentPhase == Role.SPYMASTER) return PlayerRoles.RED_SPYMASTER
         return PlayerRoles.RED_OPERATIVE
     }
-    if (currentPhase == Role.SPYMASTER) return PlayerRoles.BLUE_SPYMASTER
-    return PlayerRoles.BLUE_OPERATIVE
+    if (currentTurn == Team.BLUE) {
+        if (currentPhase == Role.SPYMASTER) return PlayerRoles.BLUE_SPYMASTER
+        return PlayerRoles.BLUE_OPERATIVE
+    }
+    return PlayerRoles.NONE
 }

--- a/app/src/main/java/com/codenames/frontend/network/dto/LobbyResponse.kt
+++ b/app/src/main/java/com/codenames/frontend/network/dto/LobbyResponse.kt
@@ -4,7 +4,8 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class LobbyResponse(
-    val lobbyCode: String,
-    val playerList: List<PlayerDto>,
-    val isStarted: Boolean,
+    val lobbyCode: String = "",
+    val playerList: List<PlayerDto>? = emptyList(),
+    val isStarted: Boolean = false,
+    val message: String = "",
 )

--- a/app/src/main/java/com/codenames/frontend/ui/composables/ErrorDialog.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/composables/ErrorDialog.kt
@@ -1,0 +1,33 @@
+package com.codenames.frontend.ui.composables
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import com.codenames.frontend.ui.buttons.AppButton
+import com.codenames.frontend.ui.theme.AppInk
+
+@Suppress("ktlint:standard:function-naming")
+@Composable
+fun ErrorDialog(
+    message: String,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text("Something went wrong")
+        },
+        text = {
+            Text(
+                text = message,
+                color = AppInk,
+            )
+        },
+        confirmButton = {
+            AppButton(
+                text = "OK",
+                onClick = onDismiss,
+            )
+        },
+    )
+}

--- a/app/src/main/java/com/codenames/frontend/ui/composables/ErrorDialog.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/composables/ErrorDialog.kt
@@ -4,7 +4,12 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import com.codenames.frontend.ui.buttons.AppButton
-import com.codenames.frontend.ui.theme.AppInk
+import com.codenames.frontend.ui.buttons.AppButtonStyle
+import com.codenames.frontend.ui.theme.AppBlue
+import com.codenames.frontend.ui.theme.AppInkDark
+import com.codenames.frontend.ui.theme.AppInkOverlay
+import com.codenames.frontend.ui.theme.AppSurface
+import com.codenames.frontend.ui.theme.AppWhite
 
 @Suppress("ktlint:standard:function-naming")
 @Composable
@@ -14,19 +19,24 @@ fun ErrorDialog(
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
+        containerColor = AppSurface,
+        titleContentColor = AppInkDark,
+        textContentColor = AppInkOverlay,
         title = {
             Text("Something went wrong")
         },
         text = {
-            Text(
-                text = message,
-                color = AppInk,
-            )
+            Text(text = message)
         },
         confirmButton = {
             AppButton(
                 text = "OK",
                 onClick = onDismiss,
+                style =
+                    AppButtonStyle(
+                        containerColor = AppBlue,
+                        contentColor = AppWhite,
+                    ),
             )
         },
     )

--- a/app/src/main/java/com/codenames/frontend/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/navigation/NavGraph.kt
@@ -39,7 +39,7 @@ fun NavGraph(
     val connectionState by gameViewModel.connectionState.collectAsState()
     val chatErrorMessage by chatViewModel.errorMessage.collectAsState()
 
-    val errorMessage =
+    val errorMessage: String? =
         lobbyState.error
             ?: (connectionState as? ConnectionState.Error)?.message
             ?: chatErrorMessage
@@ -106,9 +106,9 @@ fun NavGraph(
                 }
             }
 
-            errorMessage?.let { message ->
+            if (errorMessage != null) {
                 ErrorDialog(
-                    message = message,
+                    message = errorMessage,
                     onDismiss = {
                         lobbyViewModel.clearError()
                         gameViewModel.clearError()

--- a/app/src/main/java/com/codenames/frontend/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/navigation/NavGraph.kt
@@ -3,10 +3,14 @@ package com.codenames.frontend.ui.navigation
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.codenames.frontend.data.model.enums.ConnectionState
+import com.codenames.frontend.ui.composables.ErrorDialog
 import com.codenames.frontend.ui.screens.GameScreenWrapper
 import com.codenames.frontend.ui.screens.GameSettingsScreen
 import com.codenames.frontend.ui.screens.JoinlobbyScreen
@@ -30,6 +34,15 @@ fun NavGraph(
     chatViewModel: ChatViewModel = hiltViewModel(),
 ) {
     val navController = rememberNavController()
+
+    val lobbyState by lobbyViewModel.state.collectAsState()
+    val connectionState by gameViewModel.connectionState.collectAsState()
+    val chatErrorMessage by chatViewModel.errorMessage.collectAsState()
+
+    val errorMessage =
+        lobbyState.error
+            ?: (connectionState as? ConnectionState.Error)?.message
+            ?: chatErrorMessage
 
     @Suppress("UnusedBoxWithConstraintsScope")
     BoxWithConstraints {
@@ -91,6 +104,17 @@ fun NavGraph(
                 composable(Screen.Settings.route) {
                     SettingsScreen(navController)
                 }
+            }
+
+            errorMessage?.let { message ->
+                ErrorDialog(
+                    message = message,
+                    onDismiss = {
+                        lobbyViewModel.clearError()
+                        gameViewModel.clearError()
+                        chatViewModel.clearError()
+                    },
+                )
             }
         }
     }

--- a/app/src/main/java/com/codenames/frontend/ui/screens/JoinLobbyScreen.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/JoinLobbyScreen.kt
@@ -171,16 +171,6 @@ fun JoinlobbyScreen(
                     modifier = Modifier.padding(top = dimensions.itemSpacing),
                 )
             }
-
-            /* old error line, replaced by error pop-up
-            state.error?.let { error ->
-                Text(
-                    text = error,
-                    color = AppRed,
-                    fontSize = dimensions.bodyFontSize,
-                    modifier = Modifier.padding(top = dimensions.itemSpacing),
-                )
-            }*/
         }
 
         SettingsCornerButton(

--- a/app/src/main/java/com/codenames/frontend/ui/screens/JoinLobbyScreen.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/JoinLobbyScreen.kt
@@ -39,7 +39,6 @@ import com.codenames.frontend.ui.inputs.AppTextFieldType
 import com.codenames.frontend.ui.navigation.Screen
 import com.codenames.frontend.ui.theme.AppBackground
 import com.codenames.frontend.ui.theme.AppInk
-import com.codenames.frontend.ui.theme.AppRed
 import com.codenames.frontend.ui.theme.AppWhite
 import com.codenames.frontend.ui.theme.LocalResponsiveDimensions
 import com.codenames.frontend.ui.theme.blueGradient
@@ -173,6 +172,7 @@ fun JoinlobbyScreen(
                 )
             }
 
+            /* old error line, replaced by error pop-up
             state.error?.let { error ->
                 Text(
                     text = error,
@@ -180,7 +180,7 @@ fun JoinlobbyScreen(
                     fontSize = dimensions.bodyFontSize,
                     modifier = Modifier.padding(top = dimensions.itemSpacing),
                 )
-            }
+            }*/
         }
 
         SettingsCornerButton(

--- a/app/src/main/java/com/codenames/frontend/ui/screens/LobbyScreen.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/LobbyScreen.kt
@@ -41,7 +41,6 @@ import com.codenames.frontend.ui.theme.AppBackground
 import com.codenames.frontend.ui.theme.AppBlack
 import com.codenames.frontend.ui.theme.AppBlueLight
 import com.codenames.frontend.ui.theme.AppMutedDark
-import com.codenames.frontend.ui.theme.AppRed
 import com.codenames.frontend.ui.theme.AppRedLight
 import com.codenames.frontend.ui.theme.AppWhite
 import com.codenames.frontend.ui.theme.LocalResponsiveDimensions
@@ -179,6 +178,7 @@ fun LobbyScreen(
             )
         }
 
+        /* old error line, replaced by error pop-up
         lobbyUiState.error?.let { error ->
             Text(
                 text = error,
@@ -189,7 +189,7 @@ fun LobbyScreen(
                         .align(Alignment.BottomCenter)
                         .padding(bottom = dimensions.screenPadding),
             )
-        }
+        } */
 
         SettingsCornerButton(
             onClick = {

--- a/app/src/main/java/com/codenames/frontend/ui/screens/LobbyScreen.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/LobbyScreen.kt
@@ -178,19 +178,6 @@ fun LobbyScreen(
             )
         }
 
-        /* old error line, replaced by error pop-up
-        lobbyUiState.error?.let { error ->
-            Text(
-                text = error,
-                color = AppRed,
-                fontSize = dimensions.bodyFontSize,
-                modifier =
-                    Modifier
-                        .align(Alignment.BottomCenter)
-                        .padding(bottom = dimensions.screenPadding),
-            )
-        } */
-
         SettingsCornerButton(
             onClick = {
                 navController.navigate(Screen.Settings.route)

--- a/app/src/main/java/com/codenames/frontend/ui/screens/StartScreen.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/StartScreen.kt
@@ -117,16 +117,6 @@ fun StartScreen(
                     modifier = Modifier.padding(top = dimensions.itemSpacing),
                 )
             }
-
-            /* old error line, replaced by error pop-up
-            lobbyState.error?.let { error ->
-                Text(
-                    text = error,
-                    color = AppRed,
-                    fontSize = dimensions.bodyFontSize,
-                    modifier = Modifier.padding(top = dimensions.itemSpacing),
-                )
-            }*/
         }
 
         SettingsCornerButton(

--- a/app/src/main/java/com/codenames/frontend/ui/screens/StartScreen.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/StartScreen.kt
@@ -23,7 +23,6 @@ import com.codenames.frontend.ui.buttons.SettingsCornerButton
 import com.codenames.frontend.ui.navigation.Screen
 import com.codenames.frontend.ui.theme.AppBackground
 import com.codenames.frontend.ui.theme.AppInk
-import com.codenames.frontend.ui.theme.AppRed
 import com.codenames.frontend.ui.theme.LocalResponsiveDimensions
 import com.codenames.frontend.ui.theme.blueGradient
 import com.codenames.frontend.ui.theme.greenGradient
@@ -119,6 +118,7 @@ fun StartScreen(
                 )
             }
 
+            /* old error line, replaced by error pop-up
             lobbyState.error?.let { error ->
                 Text(
                     text = error,
@@ -126,7 +126,7 @@ fun StartScreen(
                     fontSize = dimensions.bodyFontSize,
                     modifier = Modifier.padding(top = dimensions.itemSpacing),
                 )
-            }
+            }*/
         }
 
         SettingsCornerButton(

--- a/app/src/main/java/com/codenames/frontend/viewmodel/ChatViewModel.kt
+++ b/app/src/main/java/com/codenames/frontend/viewmodel/ChatViewModel.kt
@@ -2,6 +2,7 @@ package com.codenames.frontend.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.codenames.frontend.data.error.ErrorMessageMapper
 import com.codenames.frontend.data.model.ChatLists
 import com.codenames.frontend.data.model.enums.ChatTab
 import com.codenames.frontend.data.model.enums.Role
@@ -23,6 +24,9 @@ class ChatViewModel
         private val _chatState = MutableStateFlow(ChatLists())
         val chatState: StateFlow<ChatLists> = _chatState
 
+        private val _errorMessage = MutableStateFlow<String?>(null)
+        val errorMessage: StateFlow<String?> = _errorMessage
+
         fun subscribeToChats(
             username: String,
             lobbyCode: String,
@@ -30,48 +34,60 @@ class ChatViewModel
             role: String,
         ) {
             viewModelScope.launch {
-                chatRepository
-                    .observeLobbyChat(
-                        lobbyCode = lobbyCode,
-                        currentUsername = username,
-                    ).collect { msg ->
-                        _chatState.update {
-                            it.copy(
-                                lobbyMessages = it.lobbyMessages + msg,
-                            )
+                try {
+                    chatRepository
+                        .observeLobbyChat(
+                            lobbyCode = lobbyCode,
+                            currentUsername = username,
+                        ).collect { msg ->
+                            _chatState.update {
+                                it.copy(
+                                    lobbyMessages = it.lobbyMessages + msg,
+                                )
+                            }
                         }
-                    }
+                } catch (e: Exception) {
+                    setError(e)
+                }
             }
 
             viewModelScope.launch {
-                chatRepository
-                    .observeTeamChat(
-                        lobbyCode = lobbyCode,
-                        team = team,
-                        currentUsername = username,
-                    ).collect { msg ->
-                        _chatState.update {
-                            it.copy(
-                                teamMessages = it.teamMessages + msg,
-                            )
-                        }
-                    }
-            }
-
-            if (role == Role.OPERATIVE.name) {
-                viewModelScope.launch {
+                try {
                     chatRepository
-                        .observeOperativeChat(
+                        .observeTeamChat(
                             lobbyCode = lobbyCode,
                             team = team,
                             currentUsername = username,
                         ).collect { msg ->
                             _chatState.update {
                                 it.copy(
-                                    operativeMessages = it.operativeMessages + msg,
+                                    teamMessages = it.teamMessages + msg,
                                 )
                             }
                         }
+                } catch (e: Exception) {
+                    setError(e)
+                }
+            }
+
+            if (role == Role.OPERATIVE.name) {
+                viewModelScope.launch {
+                    try {
+                        chatRepository
+                            .observeOperativeChat(
+                                lobbyCode = lobbyCode,
+                                team = team,
+                                currentUsername = username,
+                            ).collect { msg ->
+                                _chatState.update {
+                                    it.copy(
+                                        operativeMessages = it.operativeMessages + msg,
+                                    )
+                                }
+                            }
+                    } catch (e: Exception) {
+                        setError(e)
+                    }
                 }
             }
         }
@@ -82,11 +98,15 @@ class ChatViewModel
             content: String,
         ) {
             viewModelScope.launch {
-                chatRepository.sendLobbyMessage(
-                    lobbyCode = lobbyCode,
-                    username = username,
-                    text = content,
-                )
+                try {
+                    chatRepository.sendLobbyMessage(
+                        lobbyCode = lobbyCode,
+                        username = username,
+                        text = content,
+                    )
+                } catch (e: Exception) {
+                    setError(e)
+                }
             }
         }
 
@@ -97,12 +117,16 @@ class ChatViewModel
             content: String,
         ) {
             viewModelScope.launch {
-                chatRepository.sendTeamMessage(
-                    lobbyCode = lobbyCode,
-                    team = team,
-                    username = username,
-                    text = content,
-                )
+                try {
+                    chatRepository.sendTeamMessage(
+                        lobbyCode = lobbyCode,
+                        team = team,
+                        username = username,
+                        text = content,
+                    )
+                } catch (e: Exception) {
+                    setError(e)
+                }
             }
         }
 
@@ -113,12 +137,16 @@ class ChatViewModel
             content: String,
         ) {
             viewModelScope.launch {
-                chatRepository.sendOperativeMessage(
-                    lobbyCode = lobbyCode,
-                    team = team,
-                    username = username,
-                    text = content,
-                )
+                try {
+                    chatRepository.sendOperativeMessage(
+                        lobbyCode = lobbyCode,
+                        team = team,
+                        username = username,
+                        text = content,
+                    )
+                } catch (e: Exception) {
+                    setError(e)
+                }
             }
         }
 
@@ -162,5 +190,13 @@ class ChatViewModel
                         )
                     }
             }
+        }
+
+        fun clearError() {
+            _errorMessage.value = null
+        }
+
+        private fun setError(error: Throwable) {
+            _errorMessage.value = ErrorMessageMapper.toUserMessage(error)
         }
     }

--- a/app/src/main/java/com/codenames/frontend/viewmodel/GameViewModel.kt
+++ b/app/src/main/java/com/codenames/frontend/viewmodel/GameViewModel.kt
@@ -3,6 +3,7 @@ package com.codenames.frontend.viewmodel
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.codenames.frontend.data.error.ErrorMessageMapper
 import com.codenames.frontend.data.model.GameState
 import com.codenames.frontend.data.model.RejoinState
 import com.codenames.frontend.data.model.enums.ConnectionState
@@ -23,8 +24,6 @@ import java.util.UUID
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds
 
-private const val CONNECTION_ERROR_MESSAGE = "Connection error"
-
 @HiltViewModel
 class GameViewModel
     @Inject
@@ -36,6 +35,7 @@ class GameViewModel
 
         private val _uiState = MutableStateFlow(GameState())
         val uiState: StateFlow<GameState> = _uiState
+
         private val _connectionState = MutableStateFlow<ConnectionState>(ConnectionState.IDLE)
         val connectionState: StateFlow<ConnectionState> = _connectionState
 
@@ -69,7 +69,7 @@ class GameViewModel
                             sendGameStart(lobbyCode)
                         }
                     } catch (e: Exception) {
-                        _connectionState.value = ConnectionState.Error(e.message ?: CONNECTION_ERROR_MESSAGE)
+                        setConnectionError(e)
                     }
                 }
         }
@@ -79,7 +79,11 @@ class GameViewModel
                 return
             }
             viewModelScope.launch {
-                gameRepository.startGame(lobbyCode)
+                try {
+                    gameRepository.startGame(lobbyCode)
+                } catch (e: Exception) {
+                    setConnectionError(e)
+                }
             }
         }
 
@@ -99,7 +103,7 @@ class GameViewModel
                 try {
                     gameRepository.submitClue(lobbyCode, word, count, team)
                 } catch (e: Exception) {
-                    _connectionState.value = ConnectionState.Error(e.message ?: CONNECTION_ERROR_MESSAGE)
+                    setConnectionError(e)
                 }
             }
         }
@@ -119,7 +123,7 @@ class GameViewModel
                 try {
                     gameRepository.submitGuess(lobbyCode, position, team)
                 } catch (e: Exception) {
-                    _connectionState.value = ConnectionState.Error(e.message ?: CONNECTION_ERROR_MESSAGE)
+                    setConnectionError(e)
                 }
             }
         }
@@ -141,7 +145,7 @@ class GameViewModel
                         gameRepository.submitGuess(lobbyCode, position, team)
                     }
                 } catch (e: Exception) {
-                    _connectionState.value = ConnectionState.Error(e.message ?: CONNECTION_ERROR_MESSAGE)
+                    setConnectionError(e)
                 }
             }
         }
@@ -160,7 +164,7 @@ class GameViewModel
                 try {
                     gameRepository.passTurn(lobbyCode, team)
                 } catch (e: Exception) {
-                    _connectionState.value = ConnectionState.Error(e.message ?: CONNECTION_ERROR_MESSAGE)
+                    setConnectionError(e)
                 }
             }
         }
@@ -178,9 +182,36 @@ class GameViewModel
 
             if (lobbyCode != null && team != null && role != null) {
                 viewModelScope.launch {
-                    gameRepository.sendRejoin(username, userId, lobbyCode, role, team)
+                    try {
+                        gameRepository.sendRejoin(username, userId, lobbyCode, role, team)
+                    } catch (e: Exception) {
+                        setConnectionError(e)
+                    }
                 }
             }
+        }
+
+        fun handleMessage(message: GameMessage) {
+            if (!message.error.isNullOrBlank()) {
+                _connectionState.value = ConnectionState.Error(message.error)
+                return
+            }
+
+            val state = message.toGameState()
+            Log.d("GameViewModel", "New Game State: $state")
+            _uiState.update {
+                state
+            }
+        }
+
+        fun clearError() {
+            if (_connectionState.value is ConnectionState.Error) {
+                _connectionState.value = ConnectionState.IDLE
+            }
+        }
+
+        private fun setConnectionError(error: Throwable) {
+            _connectionState.value = ConnectionState.Error(ErrorMessageMapper.toUserMessage(error))
         }
 
         private fun Team.isActiveOperativeTurn(turn: PlayerRoles): Boolean =
@@ -190,12 +221,4 @@ class GameViewModel
         private fun Team.isActiveSpymasterTurn(turn: PlayerRoles): Boolean =
             (this == Team.BLUE && turn == PlayerRoles.BLUE_SPYMASTER) ||
                 (this == Team.RED && turn == PlayerRoles.RED_SPYMASTER)
-
-        fun handleMessage(message: GameMessage) {
-            val state = message.toGameState()
-            Log.d("GameViewModel", "New Game State: $state")
-            _uiState.update {
-                state
-            }
-        }
     }

--- a/app/src/main/java/com/codenames/frontend/viewmodel/LobbyViewModel.kt
+++ b/app/src/main/java/com/codenames/frontend/viewmodel/LobbyViewModel.kt
@@ -3,6 +3,7 @@ package com.codenames.frontend.viewmodel
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.codenames.frontend.data.error.ErrorMessageMapper
 import com.codenames.frontend.data.model.LobbyUiState
 import com.codenames.frontend.data.model.Player
 import com.codenames.frontend.data.model.enums.ChatTab
@@ -50,7 +51,7 @@ class LobbyViewModel
                     }
                     startPolling(response.lobbyCode)
                 } catch (e: Exception) {
-                    setError(e.message)
+                    setError(e)
                 } finally {
                     setLoading(false)
                 }
@@ -79,7 +80,7 @@ class LobbyViewModel
                     updateUiState(_state.value.players)
                     startPolling(response.lobbyCode)
                 } catch (e: Exception) {
-                    setError(e.message)
+                    setError(e)
                 } finally {
                     setLoading(false)
                 }
@@ -111,7 +112,7 @@ class LobbyViewModel
                     stopPolling()
                     successful = true
                 } catch (e: Exception) {
-                    setError(e.message)
+                    setError(e)
                     successful = false
                 } finally {
                     setLoading(false)
@@ -143,7 +144,7 @@ class LobbyViewModel
                     }
                     updateUiState(_state.value.players)
                 } catch (e: Exception) {
-                    setError(e.message)
+                    setError(e)
                 } finally {
                     setLoading(false)
                 }
@@ -223,7 +224,7 @@ class LobbyViewModel
                         }
                         updateUiState(_state.value.players)
                     } catch (e: Exception) {
-                        setError(e.message)
+                        setError(e)
                     } finally {
                         Log.d("LobbyViewModel", "Game start sent. Current state: ${_state.value}")
                         setLoading(false)
@@ -234,6 +235,12 @@ class LobbyViewModel
 
         fun startUpdateAfterRejoin(lobbyCode: String) {
             startPolling(lobbyCode)
+        }
+
+        fun clearError() {
+            _state.update {
+                it.copy(error = null)
+            }
         }
 
         private fun cleanup() {
@@ -286,7 +293,7 @@ class LobbyViewModel
                             }
                             updateUiState(_state.value.players)
                         } catch (e: Exception) {
-                            setError(e.message)
+                            setError(e)
                             return@launch
                         }
 
@@ -298,6 +305,10 @@ class LobbyViewModel
         private fun stopPolling() {
             pollingJob?.cancel()
             pollingJob = null
+        }
+
+        private fun setError(error: Throwable) {
+            setError(ErrorMessageMapper.toUserMessage(error))
         }
 
         private fun setError(msg: String?) {
@@ -319,7 +330,6 @@ class LobbyViewModel
             }
         }
 
-        // for testing polling
         internal fun startPollingForTest(lobbyCode: String) {
             startPolling(lobbyCode)
         }

--- a/app/src/test/java/com/codenames/frontend/data/error/ErrorMessageMapperTest.kt
+++ b/app/src/test/java/com/codenames/frontend/data/error/ErrorMessageMapperTest.kt
@@ -1,0 +1,112 @@
+package com.codenames.frontend.data.error
+
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+import java.io.IOException
+
+class ErrorMessageMapperTest {
+    @Test
+    fun toUserMessage_httpExceptionWithBackendMessage_returnsBackendMessage() {
+        val errorBody =
+            """
+            {
+              "message": "Could not find lobby.",
+              "lobbyCode": "ABCDE",
+              "playerList": null,
+              "isStarted": false
+            }
+            """.trimIndent()
+                .toResponseBody("application/json".toMediaType())
+
+        val exception = HttpException(Response.error<Any>(400, errorBody))
+
+        val result = ErrorMessageMapper.toUserMessage(exception)
+
+        assertEquals("Could not find lobby.", result)
+    }
+
+    @Test
+    fun toUserMessage_badRequestWithoutBackendMessage_returnsUserFriendlyMessage() {
+        val exception =
+            HttpException(
+                Response.error<Any>(
+                    400,
+                    "{}".toResponseBody("application/json".toMediaType()),
+                ),
+            )
+
+        val result = ErrorMessageMapper.toUserMessage(exception)
+
+        assertEquals(
+            "The request could not be processed. Please check your input.",
+            result,
+        )
+    }
+
+    @Test
+    fun toUserMessage_notFoundWithoutBackendMessage_returnsUserFriendlyMessage() {
+        val exception =
+            HttpException(
+                Response.error<Any>(
+                    404,
+                    "{}".toResponseBody("application/json".toMediaType()),
+                ),
+            )
+
+        val result = ErrorMessageMapper.toUserMessage(exception)
+
+        assertEquals(
+            "The requested lobby could not be found.",
+            result,
+        )
+    }
+
+    @Test
+    fun toUserMessage_serverErrorWithoutBackendMessage_returnsUserFriendlyMessage() {
+        val exception =
+            HttpException(
+                Response.error<Any>(
+                    500,
+                    "{}".toResponseBody("application/json".toMediaType()),
+                ),
+            )
+
+        val result = ErrorMessageMapper.toUserMessage(exception)
+
+        assertEquals(
+            "The server has a problem right now. Please try again later.",
+            result,
+        )
+    }
+
+    @Test
+    fun toUserMessage_ioException_returnsConnectionMessage() {
+        val result = ErrorMessageMapper.toUserMessage(IOException())
+
+        assertEquals(
+            "Could not connect to the server. Please check your connection.",
+            result,
+        )
+    }
+
+    @Test
+    fun toUserMessage_exceptionWithMessage_returnsMessage() {
+        val result = ErrorMessageMapper.toUserMessage(RuntimeException("Network error"))
+
+        assertEquals("Network error", result)
+    }
+
+    @Test
+    fun toUserMessage_exceptionWithoutMessage_returnsGenericMessage() {
+        val result = ErrorMessageMapper.toUserMessage(RuntimeException())
+
+        assertEquals(
+            "Something went wrong. Please try again.",
+            result,
+        )
+    }
+}

--- a/app/src/test/java/com/codenames/frontend/viewmodel/ChatViewModelTest.kt
+++ b/app/src/test/java/com/codenames/frontend/viewmodel/ChatViewModelTest.kt
@@ -5,24 +5,36 @@ import com.codenames.frontend.data.model.enums.ChatTab
 import com.codenames.frontend.data.model.enums.Role
 import com.codenames.frontend.data.model.enums.Team
 import com.codenames.frontend.data.repository.ChatRepository
+import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 
-@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 class ChatViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+
     private lateinit var repository: ChatRepository
     private lateinit var viewModel: ChatViewModel
 
     @Before
     fun setup() {
+        Dispatchers.setMain(dispatcher)
+
         repository = mockk(relaxed = true)
 
         every {
@@ -40,6 +52,11 @@ class ChatViewModelTest {
         viewModel = ChatViewModel(repository)
     }
 
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
     @Test
     fun sendChatMessage_global_sendsLobbyMessage() =
         runTest {
@@ -51,6 +68,8 @@ class ChatViewModelTest {
                 content = "Hallo",
                 availableChatTabs = listOf(ChatTab.GLOBAL),
             )
+
+            advanceUntilIdle()
 
             coVerify {
                 repository.sendLobbyMessage(
@@ -76,6 +95,8 @@ class ChatViewModelTest {
                         ChatTab.TEAM,
                     ),
             )
+
+            advanceUntilIdle()
 
             coVerify {
                 repository.sendTeamMessage(
@@ -104,6 +125,8 @@ class ChatViewModelTest {
                     ),
             )
 
+            advanceUntilIdle()
+
             coVerify {
                 repository.sendOperativeMessage(
                     "ABCD",
@@ -130,6 +153,8 @@ class ChatViewModelTest {
                     ),
             )
 
+            advanceUntilIdle()
+
             coVerify(exactly = 0) {
                 repository.sendOperativeMessage(
                     any(),
@@ -151,6 +176,8 @@ class ChatViewModelTest {
                 content = "Hallo",
                 availableChatTabs = listOf(ChatTab.GLOBAL),
             )
+
+            advanceUntilIdle()
 
             coVerify(exactly = 0) {
                 repository.sendLobbyMessage(any(), any(), any())
@@ -208,10 +235,6 @@ class ChatViewModelTest {
             advanceUntilIdle()
 
             val messages = viewModel.chatState.value.lobbyMessages
-            if (messages.isNotEmpty()) {
-                println("First sender: ${messages.first().sender}")
-                println("First text: ${messages.first().text}")
-            }
 
             assertEquals(1, messages.size)
 
@@ -219,5 +242,51 @@ class ChatViewModelTest {
 
             assertEquals("Anna", first.sender)
             assertEquals("Hallo", first.text)
+        }
+
+    @Test
+    fun sendLobbyMessage_whenRepositoryThrows_setsErrorMessage() =
+        runTest {
+            coEvery {
+                repository.sendLobbyMessage(any(), any(), any())
+            } throws RuntimeException("Chat message could not be sent")
+
+            viewModel.sendLobbyMessage(
+                lobbyCode = "ABCD",
+                username = "Max",
+                content = "Hallo",
+            )
+
+            advanceUntilIdle()
+
+            assertEquals(
+                "Chat message could not be sent",
+                viewModel.errorMessage.value,
+            )
+        }
+
+    @Test
+    fun clearError_resetsErrorMessage() =
+        runTest {
+            coEvery {
+                repository.sendLobbyMessage(any(), any(), any())
+            } throws RuntimeException("Chat message could not be sent")
+
+            viewModel.sendLobbyMessage(
+                lobbyCode = "ABCD",
+                username = "Max",
+                content = "Hallo",
+            )
+
+            advanceUntilIdle()
+
+            assertEquals(
+                "Chat message could not be sent",
+                viewModel.errorMessage.value,
+            )
+
+            viewModel.clearError()
+
+            assertNull(viewModel.errorMessage.value)
         }
 }

--- a/app/src/test/java/com/codenames/frontend/viewmodel/GameViewModelTest.kt
+++ b/app/src/test/java/com/codenames/frontend/viewmodel/GameViewModelTest.kt
@@ -617,4 +617,41 @@ class GameViewModelTest {
                 gameRepository.sendRejoin(any(), any(), any(), any(), any())
             }
         }
+
+    @Test
+    fun handleMessage_withError_setsConnectionError() =
+        runTest {
+            val message =
+                GameMessage(
+                    error = "Not your turn.",
+                )
+
+            viewModel.handleMessage(message)
+
+            val state = viewModel.connectionState.value
+
+            assertTrue(state is ConnectionState.Error)
+            assertEquals(
+                "Not your turn.",
+                (state as ConnectionState.Error).message,
+            )
+        }
+
+    @Test
+    fun clearError_whenConnectionStateIsError_resetsToIdle() =
+        runTest {
+            coEvery {
+                client.connectStomp()
+            } throws RuntimeException("Connection failed")
+
+            viewModel.connect(lobbyCode)
+
+            advanceUntilIdle()
+
+            assertTrue(viewModel.connectionState.value is ConnectionState.Error)
+
+            viewModel.clearError()
+
+            assertEquals(ConnectionState.IDLE, viewModel.connectionState.value)
+        }
 }

--- a/app/src/test/java/com/codenames/frontend/viewmodel/LobbyViewModelTest.kt
+++ b/app/src/test/java/com/codenames/frontend/viewmodel/LobbyViewModelTest.kt
@@ -328,7 +328,7 @@ class LobbyViewModelTest {
 
             val state = viewModel.state.value
 
-            assertEquals("Unknown error", state.error)
+            assertEquals("Something went wrong. Please try again.", state.error)
             assertFalse(state.isLoading)
         }
 
@@ -349,7 +349,7 @@ class LobbyViewModelTest {
 
             val state = viewModel.state.value
 
-            assertEquals("Unknown error", state.error)
+            assertEquals("Something went wrong. Please try again.", state.error)
             assertFalse(state.isLoading)
         }
 
@@ -1143,5 +1143,25 @@ class LobbyViewModelTest {
                 listOf(ChatTab.GLOBAL, ChatTab.TEAM, ChatTab.OPERATIVES),
                 viewModel.getAvailableChatTabsForUser("Alice"),
             )
+        }
+
+    @Test
+    fun clearError_resetsError() =
+        runTest {
+            val repository = mockk<LobbyRepository>()
+
+            coEvery { repository.createLobby(any()) } throws RuntimeException("Network error")
+
+            val viewModel = LobbyViewModel(repository)
+
+            viewModel.createLobby("Max")
+
+            advanceUntilIdle()
+
+            assertEquals("Network error", viewModel.state.value.error)
+
+            viewModel.clearError()
+
+            assertNull(viewModel.state.value.error)
         }
 }


### PR DESCRIPTION
## Context

This PR improves frontend error handling for backend and connection errors.

Until now, several errors were either only handled locally, displayed as technical messages, or shown as small inline red text blocks. This made it hard for users to understand what went wrong, especially when the backend returned a meaningful error description.

The goal of this PR is to show user-readable error messages in a consistent popup dialog whenever relevant errors occur.

## Description

The frontend now has a central error message handling flow.

Backend error responses are parsed and their `message` field is extracted whenever possible. This means users see the actual error description sent by the backend instead of only generic technical information or HTTP status codes.

A reusable `ErrorDialog` was added and is displayed globally through the `NavGraph`. Errors from lobby actions, game actions, WebSocket/game messages, and chat actions are collected and shown in this dialog. The old inline red error text blocks were removed to avoid duplicated error output.

Fallback messages are still provided for cases where no backend description is available, for example network errors or unexpected failures.

## Changes in the code base

- Added central `ErrorMessageMapper`
- Added reusable `ErrorDialog` composable
- Extended `LobbyResponse` to include backend error descriptions via `message`
- Updated lobby response mapping to handle missing/null player lists safely
- Updated `LobbyViewModel` to map caught exceptions to user-readable error messages
- Added `clearError()` handling to `LobbyViewModel`
- Updated `GameViewModel` to map REST/WebSocket/game errors to user-readable messages
- Added handling for backend game message errors
- Added `clearError()` handling to `GameViewModel`
- Updated `ChatViewModel` to expose chat-related error messages
- Added error handling for chat subscriptions and message sending
- Added `clearError()` handling to `ChatViewModel`
- Updated `NavGraph` to collect lobby, game, and chat errors centrally
- Displayed collected errors through the shared `ErrorDialog`
- Removed old inline red error text blocks from lobby/start/join screens
- Added tests for error message mapping
- Updated existing ViewModel tests for the new fallback error messages
- Added/updated tests for clearing and exposing errors in affected ViewModels
- Verified `testDebugUnitTest`
- Verified `ktlintFormat`

## Changes outside the code base

N/A

## Additional information

This PR does not change backend error generation. It only improves how already existing backend error descriptions are received, mapped, and displayed in the Android frontend.

If no backend error description is available, the frontend falls back to understandable generic messages instead of exposing technical error details to the user.