### PR TITLE
Player UUID integration

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -80,6 +80,7 @@
                   <entry key="Pixel_9" value="120" />
                   <entry key="Status" value="80" />
                   <entry key="Tests" value="360" />
+                  <entry key="Xiaomi 23090RA98G" value="120" />
                 </map>
               </option>
             </AndroidTestResultsTableState>

--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -38,6 +38,23 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-974870950">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_7" value="120" />
+                  <entry key="Pixel_9" value="120" />
+                  <entry key="Pixel_9a" value="120" />
+                  <entry key="Status" value="80" />
+                  <entry key="Tests" value="360" />
+                  <entry key="Xiaomi 23090RA98G" value="120" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="27987255">
           <value>
             <AndroidTestResultsTableState>

--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -58,6 +58,10 @@
                 <map>
                   <entry key="Duration" value="90" />
                   <entry key="Pixel_6" value="120" />
+                  <entry key="Pixel_7" value="120" />
+                  <entry key="Pixel_8" value="120" />
+                  <entry key="Pixel_9" value="120" />
+                  <entry key="Status" value="80" />
                   <entry key="Tests" value="360" />
                 </map>
               </option>

--- a/app/src/androidTest/java/com/codenames/frontend/GameboardScreenTest.kt
+++ b/app/src/androidTest/java/com/codenames/frontend/GameboardScreenTest.kt
@@ -1,7 +1,5 @@
 package com.codenames.frontend
 
-import androidx.compose.foundation.layout.offset
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -50,7 +48,7 @@ class GameboardScreenTest {
                 onHintChange = { _, _ -> },
                 onReveal = {},
                 onCheatRequest = {},
-                onReturnToHome = {}
+                onReturnToHome = {},
             )
         }
 
@@ -74,7 +72,7 @@ class GameboardScreenTest {
                 onHintChange = { _, _ -> },
                 onReveal = {},
                 onCheatRequest = {},
-                onReturnToHome = {}
+                onReturnToHome = {},
             )
         }
 
@@ -95,7 +93,7 @@ class GameboardScreenTest {
                 onHintChange = { _, _ -> },
                 onReveal = {},
                 onCheatRequest = {},
-                onReturnToHome = {}
+                onReturnToHome = {},
             )
         }
 
@@ -127,7 +125,7 @@ class GameboardScreenTest {
                 onHintChange = { _, _ -> },
                 onReveal = {},
                 onCheatRequest = {},
-                onReturnToHome = {}
+                onReturnToHome = {},
             )
         }
 
@@ -162,7 +160,7 @@ class GameboardScreenTest {
                 onHintChange = { _, _ -> },
                 onReveal = {},
                 onCheatRequest = {},
-                onReturnToHome = {}
+                onReturnToHome = {},
             )
         }
 
@@ -186,7 +184,7 @@ class GameboardScreenTest {
                 onHintChange = { _, _ -> },
                 onReveal = {},
                 onCheatRequest = {},
-                onReturnToHome = {}
+                onReturnToHome = {},
             )
         }
 
@@ -213,7 +211,7 @@ class GameboardScreenTest {
                 onHintChange = { _, _ -> },
                 onReveal = {},
                 onCheatRequest = {},
-                onReturnToHome = {}
+                onReturnToHome = {},
             )
         }
 
@@ -245,7 +243,7 @@ class GameboardScreenTest {
                 onHintChange = { _, _ -> },
                 onReveal = {},
                 onCheatRequest = {},
-                onReturnToHome = {}
+                onReturnToHome = {},
             )
         }
 
@@ -268,7 +266,7 @@ class GameboardScreenTest {
                 onHintChange = { _, _ -> },
                 onReveal = {},
                 onCheatRequest = {},
-                onReturnToHome = {}
+                onReturnToHome = {},
             )
         }
 
@@ -290,7 +288,7 @@ class GameboardScreenTest {
                 onHintChange = { _, _ -> },
                 onReveal = {},
                 onCheatRequest = {},
-                onReturnToHome = {}
+                onReturnToHome = {},
             )
         }
 
@@ -312,7 +310,7 @@ class GameboardScreenTest {
                 onHintChange = { _, _ -> },
                 onReveal = {},
                 onCheatRequest = {},
-                onReturnToHome = {}
+                onReturnToHome = {},
             )
         }
 
@@ -337,7 +335,7 @@ class GameboardScreenTest {
                 onReveal = {},
                 onPassTurn = { passTurnClicks++ },
                 onCheatRequest = {},
-                onReturnToHome = {}
+                onReturnToHome = {},
             )
         }
 
@@ -369,7 +367,7 @@ class GameboardScreenTest {
                 onHintChange = { _, _ -> },
                 onReveal = { positions -> revealedPositions = positions },
                 onCheatRequest = {},
-                onReturnToHome = {}
+                onReturnToHome = {},
             )
         }
 

--- a/app/src/androidTest/java/com/codenames/frontend/GameboardScreenTest.kt
+++ b/app/src/androidTest/java/com/codenames/frontend/GameboardScreenTest.kt
@@ -1,5 +1,7 @@
 package com.codenames.frontend
 
+import androidx.compose.foundation.layout.offset
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -48,6 +50,7 @@ class GameboardScreenTest {
                 onHintChange = { _, _ -> },
                 onReveal = {},
                 onCheatRequest = {},
+                onReturnToHome = {}
             )
         }
 
@@ -71,6 +74,7 @@ class GameboardScreenTest {
                 onHintChange = { _, _ -> },
                 onReveal = {},
                 onCheatRequest = {},
+                onReturnToHome = {}
             )
         }
 
@@ -91,6 +95,7 @@ class GameboardScreenTest {
                 onHintChange = { _, _ -> },
                 onReveal = {},
                 onCheatRequest = {},
+                onReturnToHome = {}
             )
         }
 
@@ -122,6 +127,7 @@ class GameboardScreenTest {
                 onHintChange = { _, _ -> },
                 onReveal = {},
                 onCheatRequest = {},
+                onReturnToHome = {}
             )
         }
 
@@ -156,6 +162,7 @@ class GameboardScreenTest {
                 onHintChange = { _, _ -> },
                 onReveal = {},
                 onCheatRequest = {},
+                onReturnToHome = {}
             )
         }
 
@@ -179,6 +186,7 @@ class GameboardScreenTest {
                 onHintChange = { _, _ -> },
                 onReveal = {},
                 onCheatRequest = {},
+                onReturnToHome = {}
             )
         }
 
@@ -205,6 +213,7 @@ class GameboardScreenTest {
                 onHintChange = { _, _ -> },
                 onReveal = {},
                 onCheatRequest = {},
+                onReturnToHome = {}
             )
         }
 
@@ -236,6 +245,7 @@ class GameboardScreenTest {
                 onHintChange = { _, _ -> },
                 onReveal = {},
                 onCheatRequest = {},
+                onReturnToHome = {}
             )
         }
 
@@ -258,6 +268,7 @@ class GameboardScreenTest {
                 onHintChange = { _, _ -> },
                 onReveal = {},
                 onCheatRequest = {},
+                onReturnToHome = {}
             )
         }
 
@@ -279,6 +290,7 @@ class GameboardScreenTest {
                 onHintChange = { _, _ -> },
                 onReveal = {},
                 onCheatRequest = {},
+                onReturnToHome = {}
             )
         }
 
@@ -300,6 +312,7 @@ class GameboardScreenTest {
                 onHintChange = { _, _ -> },
                 onReveal = {},
                 onCheatRequest = {},
+                onReturnToHome = {}
             )
         }
 
@@ -324,6 +337,7 @@ class GameboardScreenTest {
                 onReveal = {},
                 onPassTurn = { passTurnClicks++ },
                 onCheatRequest = {},
+                onReturnToHome = {}
             )
         }
 
@@ -355,6 +369,7 @@ class GameboardScreenTest {
                 onHintChange = { _, _ -> },
                 onReveal = { positions -> revealedPositions = positions },
                 onCheatRequest = {},
+                onReturnToHome = {}
             )
         }
 

--- a/app/src/androidTest/java/com/codenames/frontend/UserPreferencesDataStoreTest.kt
+++ b/app/src/androidTest/java/com/codenames/frontend/UserPreferencesDataStoreTest.kt
@@ -87,4 +87,19 @@ class UserPreferencesDataStoreTest {
             assertNull(result.lobbyRole)
             assertNull(result.lobbyTeam)
         }
+
+    @Test
+    fun removeUserId_removesUserId() =
+        runBlocking {
+            dataStore.saveUserData(
+                username = "User",
+                userId = UUID.randomUUID(),
+            )
+
+            dataStore.removeUserId()
+
+            val result = dataStore.userData.first()
+
+            assertNull(result.userId)
+        }
 }

--- a/app/src/main/java/com/codenames/frontend/data/datastore/UserPreferencesDataStore.kt
+++ b/app/src/main/java/com/codenames/frontend/data/datastore/UserPreferencesDataStore.kt
@@ -80,4 +80,10 @@ class UserPreferencesDataStore
                 prefs.remove(PreferencesKeys.LOBBY_TEAM)
             }
         }
+
+        suspend fun removeUserId() {
+            context.dataStore.edit { prefs ->
+                prefs.remove(PreferencesKeys.USER_ID)
+            }
+        }
     }

--- a/app/src/main/java/com/codenames/frontend/data/repository/GameRepository.kt
+++ b/app/src/main/java/com/codenames/frontend/data/repository/GameRepository.kt
@@ -1,6 +1,5 @@
 package com.codenames.frontend.data.repository
 
-import com.codenames.frontend.data.model.enums.Role
 import com.codenames.frontend.data.model.enums.Team
 import com.codenames.frontend.network.dto.ClueMessageDto
 import com.codenames.frontend.network.dto.GuessMessage
@@ -67,10 +66,8 @@ class GameRepository
             username: String,
             userId: UUID,
             lobbyCode: String,
-            lobbyRole: Role,
-            lobbyTeam: Team,
         ) {
-            val msg = WebSocketJoinMessage(username, lobbyCode)
+            val msg = WebSocketJoinMessage(username, lobbyCode, userId.toString())
             webSocketHandler.sendReconnectMessage(msg)
         }
     }

--- a/app/src/main/java/com/codenames/frontend/data/repository/LobbyRepository.kt
+++ b/app/src/main/java/com/codenames/frontend/data/repository/LobbyRepository.kt
@@ -25,9 +25,7 @@ class LobbyRepository
             username: String,
             lobbyCode: String,
         ): LobbyResponse {
-            Log.d("LobbyRepository", "Joining lobby $lobbyCode ")
             val msg =  api.joinLobby(lobbyCode, username)
-            Log.d("LobbyRepository", "Got Lobby Join message: $msg")
             return msg
         }
 

--- a/app/src/main/java/com/codenames/frontend/data/repository/LobbyRepository.kt
+++ b/app/src/main/java/com/codenames/frontend/data/repository/LobbyRepository.kt
@@ -1,6 +1,5 @@
 package com.codenames.frontend.data.repository
 
-import android.util.Log
 import com.codenames.frontend.data.model.enums.Role
 import com.codenames.frontend.data.model.enums.Team
 import com.codenames.frontend.network.api.LobbyApi
@@ -25,7 +24,7 @@ class LobbyRepository
             username: String,
             lobbyCode: String,
         ): LobbyResponse {
-            val msg =  api.joinLobby(lobbyCode, username)
+            val msg = api.joinLobby(lobbyCode, username)
             return msg
         }
 

--- a/app/src/main/java/com/codenames/frontend/data/repository/LobbyRepository.kt
+++ b/app/src/main/java/com/codenames/frontend/data/repository/LobbyRepository.kt
@@ -1,5 +1,6 @@
 package com.codenames.frontend.data.repository
 
+import android.util.Log
 import com.codenames.frontend.data.model.enums.Role
 import com.codenames.frontend.data.model.enums.Team
 import com.codenames.frontend.network.api.LobbyApi
@@ -23,11 +24,11 @@ class LobbyRepository
         suspend fun joinLobby(
             username: String,
             lobbyCode: String,
-            userId: UUID?
         ): LobbyResponse {
-            var id : String? = userId.toString()
-            if(id.equals("null")) id = null
-            return api.joinLobby(lobbyCode, username, id)
+            Log.d("LobbyRepository", "Joining lobby $lobbyCode ")
+            val msg =  api.joinLobby(lobbyCode, username)
+            Log.d("LobbyRepository", "Got Lobby Join message: $msg")
+            return msg
         }
 
         suspend fun getLobbyInfo(lobbyCode: String): LobbyResponse = api.getLobbyInfo(lobbyCode)

--- a/app/src/main/java/com/codenames/frontend/data/repository/LobbyRepository.kt
+++ b/app/src/main/java/com/codenames/frontend/data/repository/LobbyRepository.kt
@@ -5,6 +5,7 @@ import com.codenames.frontend.data.model.enums.Team
 import com.codenames.frontend.network.api.LobbyApi
 import com.codenames.frontend.network.dto.LobbyResponse
 import com.codenames.frontend.network.dto.PlayerDto
+import java.util.UUID
 import javax.inject.Inject
 
 class LobbyRepository
@@ -16,28 +17,34 @@ class LobbyRepository
 
         suspend fun leaveLobby(
             lobbyCode: String,
-            username: String,
-        ): LobbyResponse = api.leaveLobby(lobbyCode, username)
+            userId: UUID,
+        ): LobbyResponse = api.leaveLobby(lobbyCode, userId.toString())
 
         suspend fun joinLobby(
             username: String,
             lobbyCode: String,
-        ): LobbyResponse = api.joinLobby(lobbyCode, username)
+            userId: UUID?
+        ): LobbyResponse {
+            var id : String? = userId.toString()
+            if(id.equals("null")) id = null
+            return api.joinLobby(lobbyCode, username, id)
+        }
 
         suspend fun getLobbyInfo(lobbyCode: String): LobbyResponse = api.getLobbyInfo(lobbyCode)
 
         suspend fun changeRole(
             username: String,
+            userId: UUID,
             lobbyCode: String,
             role: Role,
             team: Team,
         ): LobbyResponse {
-            val player = PlayerDto(username, role, team, false)
+            val player = PlayerDto(username, role, team, false, userId.toString())
             return api.changeRole(lobbyCode, player)
         }
 
         suspend fun sendStartGame(
             lobbyCode: String,
-            username: String,
-        ): LobbyResponse = api.startGame(lobbyCode, username)
+            userId: UUID,
+        ): LobbyResponse = api.startGame(lobbyCode, userId.toString())
     }

--- a/app/src/main/java/com/codenames/frontend/data/repository/SessionRepository.kt
+++ b/app/src/main/java/com/codenames/frontend/data/repository/SessionRepository.kt
@@ -37,4 +37,8 @@ class SessionRepository
         suspend fun clearLobbyData() {
             dataStore.clearSessionData()
         }
+
+        suspend fun clearUserId() {
+            dataStore.removeUserId()
+        }
     }

--- a/app/src/main/java/com/codenames/frontend/network/api/LobbyApi.kt
+++ b/app/src/main/java/com/codenames/frontend/network/api/LobbyApi.kt
@@ -19,7 +19,6 @@ interface LobbyApi {
     suspend fun joinLobby(
         @Path("lobbyCode") lobbyCode: String,
         @Query("username") username: String,
-        @Query("uuid") userId: String?
     ): LobbyResponse
 
     @GET("lobby/{lobbyCode}")
@@ -42,6 +41,6 @@ interface LobbyApi {
     @GET("lobby/{lobbyCode}/start-game")
     suspend fun startGame(
         @Path("lobbyCode") lobbyCode: String,
-        @Query("username") username: String,
+        @Query("uuid") uuid: String,
     ): LobbyResponse
 }

--- a/app/src/main/java/com/codenames/frontend/network/api/LobbyApi.kt
+++ b/app/src/main/java/com/codenames/frontend/network/api/LobbyApi.kt
@@ -19,6 +19,7 @@ interface LobbyApi {
     suspend fun joinLobby(
         @Path("lobbyCode") lobbyCode: String,
         @Query("username") username: String,
+        @Query("uuid") userId: String?
     ): LobbyResponse
 
     @GET("lobby/{lobbyCode}")
@@ -29,7 +30,7 @@ interface LobbyApi {
     @GET("lobby/{lobbyCode}/leave")
     suspend fun leaveLobby(
         @Path("lobbyCode") lobbyCode: String,
-        @Query("username") username: String,
+        @Query("uuid") uuid: String,
     ): LobbyResponse
 
     @POST("lobby/{lobbyCode}/select-position")

--- a/app/src/main/java/com/codenames/frontend/network/dto/LobbyResponse.kt
+++ b/app/src/main/java/com/codenames/frontend/network/dto/LobbyResponse.kt
@@ -8,5 +8,5 @@ data class LobbyResponse(
     val playerList: List<PlayerDto>? = emptyList(),
     val isStarted: Boolean = false,
     val message: String = "",
-    val uuid: String? = null
+    val uuid: String? = null,
 )

--- a/app/src/main/java/com/codenames/frontend/network/dto/LobbyResponse.kt
+++ b/app/src/main/java/com/codenames/frontend/network/dto/LobbyResponse.kt
@@ -8,4 +8,5 @@ data class LobbyResponse(
     val playerList: List<PlayerDto>? = emptyList(),
     val isStarted: Boolean = false,
     val message: String = "",
+    val uuid: String? = null
 )

--- a/app/src/main/java/com/codenames/frontend/network/dto/PlayerDto.kt
+++ b/app/src/main/java/com/codenames/frontend/network/dto/PlayerDto.kt
@@ -10,4 +10,5 @@ data class PlayerDto(
     val role: Role? = null,
     val team: Team? = null,
     val isHost: Boolean,
+    val uuid: String? = null
 )

--- a/app/src/main/java/com/codenames/frontend/network/dto/PlayerDto.kt
+++ b/app/src/main/java/com/codenames/frontend/network/dto/PlayerDto.kt
@@ -10,5 +10,5 @@ data class PlayerDto(
     val role: Role? = null,
     val team: Team? = null,
     val isHost: Boolean,
-    val uuid: String? = null
+    val uuid: String? = null,
 )

--- a/app/src/main/java/com/codenames/frontend/network/dto/WebSocketJoinMessage.kt
+++ b/app/src/main/java/com/codenames/frontend/network/dto/WebSocketJoinMessage.kt
@@ -9,4 +9,5 @@ data class WebSocketJoinMessage(
     val username: String,
     @SerialName("code")
     val lobbyCode: String,
+    val uuid: String
 )

--- a/app/src/main/java/com/codenames/frontend/network/dto/WebSocketJoinMessage.kt
+++ b/app/src/main/java/com/codenames/frontend/network/dto/WebSocketJoinMessage.kt
@@ -9,5 +9,5 @@ data class WebSocketJoinMessage(
     val username: String,
     @SerialName("code")
     val lobbyCode: String,
-    val uuid: String
+    val uuid: String,
 )

--- a/app/src/main/java/com/codenames/frontend/network/websocket/GameWebSocketController.kt
+++ b/app/src/main/java/com/codenames/frontend/network/websocket/GameWebSocketController.kt
@@ -23,6 +23,10 @@ class GameWebSocketController
             webSocketSessionManager.connectStomp()
         }
 
+        suspend fun disconnect() {
+            webSocketSessionManager.disconnect()
+        }
+
         suspend fun startGame(msg: StartGameMessage) {
             webSocketSessionManager.getSession().convertAndSend("/app/start-game", msg, StartGameMessage.serializer())
         }

--- a/app/src/main/java/com/codenames/frontend/ui/screens/GameScreenWrapper.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/GameScreenWrapper.kt
@@ -75,5 +75,10 @@ fun GameScreenWrapper(
         onSettingsClick = {
             navController.navigate(Screen.Settings.route)
         },
+        onReturnToHome = {
+            navController.navigate(Screen.Start.route)
+            lobbyViewModel.cleanup()
+            gameViewModel.resetGameState()
+        }
     )
 }

--- a/app/src/main/java/com/codenames/frontend/ui/screens/GameScreenWrapper.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/GameScreenWrapper.kt
@@ -79,6 +79,6 @@ fun GameScreenWrapper(
             navController.navigate(Screen.Start.route)
             lobbyViewModel.cleanup()
             gameViewModel.resetGameState()
-        }
+        },
     )
 }

--- a/app/src/main/java/com/codenames/frontend/ui/screens/GameboardScreen.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/GameboardScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -133,7 +132,7 @@ fun GameboardScreen(
     onPassTurn: () -> Unit = {},
     onSendChatMessage: (ChatTab, String) -> Unit = { _, _ -> },
     onSettingsClick: (() -> Unit)? = null,
-    onReturnToHome: (() -> Unit)
+    onReturnToHome: (() -> Unit),
 ) {
     val dimensions = LocalResponsiveDimensions.current
 
@@ -178,6 +177,8 @@ fun GameboardScreen(
 
     val gameOver = gameState.winner != null
 
+    val backgroundTeam = if (winner != null) getPlayerRoleFromTeam(winner) else currentTurn
+
     val shakeDetector =
         remember {
             ShakeDetector {
@@ -209,7 +210,7 @@ fun GameboardScreen(
         modifier =
             modifier
                 .fillMaxSize()
-                .background(getTeamBackgroundColor(currentTurn)),
+                .background(getTeamBackgroundColor(backgroundTeam)),
     ) {
         Column(
             modifier =
@@ -280,18 +281,19 @@ fun GameboardScreen(
                         .weight(1f)
                         .fillMaxWidth(),
             )
-
-            HintSection(
-                isActiveSpymaster,
-                currentHint,
-                hintInput,
-                countInput,
-                onHintChange = onHintChange,
-                onInputChange,
-                onCountChange = { countInput = it },
-                keyboardController,
-                focusManager,
-            )
+            if (!gameOver) {
+                HintSection(
+                    isActiveSpymaster,
+                    currentHint,
+                    hintInput,
+                    countInput,
+                    onHintChange = onHintChange,
+                    onInputChange,
+                    onCountChange = { countInput = it },
+                    keyboardController,
+                    focusManager,
+                )
+            }
         }
 
         GameChatOverlay(
@@ -330,7 +332,7 @@ fun GameboardScreen(
                     ),
         )
 
-        if(gameOver) {
+        if (gameOver) {
             AppButton(
                 onClick = onReturnToHome,
                 text = "Return to home screen",
@@ -342,6 +344,7 @@ fun GameboardScreen(
                             end = dimensions.screenPadding,
                             bottom = dimensions.screenPadding,
                         ),
+                style = AppButtonStyle(backgroundBrush = greenGradient),
             )
         }
 
@@ -1112,4 +1115,10 @@ fun getTeamBackgroundColor(currentTurn: PlayerRoles): Color =
         PlayerRoles.BLUE_OPERATIVE, PlayerRoles.BLUE_SPYMASTER -> AppBlueTeamBackground
         PlayerRoles.RED_OPERATIVE, PlayerRoles.RED_SPYMASTER -> AppRedTeamBackground
         PlayerRoles.NONE -> AppBackground
+    }
+
+fun getPlayerRoleFromTeam(color: Team): PlayerRoles =
+    when (color) {
+        Team.RED -> PlayerRoles.RED_SPYMASTER
+        Team.BLUE -> PlayerRoles.BLUE_SPYMASTER
     }

--- a/app/src/main/java/com/codenames/frontend/ui/screens/GameboardScreen.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/GameboardScreen.kt
@@ -157,7 +157,6 @@ fun GameboardScreen(
         userRole == PlayerRoles.BLUE_SPYMASTER || userRole == PlayerRoles.RED_SPYMASTER
     val isActiveSpymaster = userRole == currentTurn && isSpymaster
     val canEndTurn = userRole == currentTurn && !isSpymaster && remainingGuesses > 0
-    val canSelectCards = canEndTurn
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusManager = LocalFocusManager.current
 
@@ -172,7 +171,7 @@ fun GameboardScreen(
 
     val onInputChange: (String) -> Unit = { hintInput = it }
 
-    val currentCanSelectCards by rememberUpdatedState(canSelectCards)
+    val currentCanSelectCards by rememberUpdatedState(canEndTurn)
     val currentSelectedCardPositions by rememberUpdatedState(selectedCardPositions)
 
     val shakeDetector =
@@ -257,7 +256,7 @@ fun GameboardScreen(
                     ),
                 selectionState =
                     BoardSelectionState(
-                        canSelectCards = canSelectCards,
+                        canSelectCards = canEndTurn,
                         selectedCardPositions = selectedCardPositions,
                         remainingGuesses = remainingGuesses,
                     ),
@@ -315,7 +314,7 @@ fun GameboardScreen(
         )
 
         DeselectAllButton(
-            isVisible = canSelectCards && selectedCardPositions.isNotEmpty(),
+            isVisible = canEndTurn && selectedCardPositions.isNotEmpty(),
             onClick = { selectedCardPositions = emptyList() },
             modifier =
                 Modifier

--- a/app/src/main/java/com/codenames/frontend/ui/screens/GameboardScreen.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/GameboardScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -132,6 +133,7 @@ fun GameboardScreen(
     onPassTurn: () -> Unit = {},
     onSendChatMessage: (ChatTab, String) -> Unit = { _, _ -> },
     onSettingsClick: (() -> Unit)? = null,
+    onReturnToHome: (() -> Unit)
 ) {
     val dimensions = LocalResponsiveDimensions.current
 
@@ -173,6 +175,8 @@ fun GameboardScreen(
 
     val currentCanSelectCards by rememberUpdatedState(canEndTurn)
     val currentSelectedCardPositions by rememberUpdatedState(selectedCardPositions)
+
+    val gameOver = gameState.winner != null
 
     val shakeDetector =
         remember {
@@ -325,6 +329,21 @@ fun GameboardScreen(
                         bottom = dimensions.screenPadding,
                     ),
         )
+
+        if(gameOver) {
+            AppButton(
+                onClick = onReturnToHome,
+                text = "Return to home screen",
+                modifier =
+                    Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(
+                            start = dimensions.screenPadding,
+                            end = dimensions.screenPadding,
+                            bottom = dimensions.screenPadding,
+                        ),
+            )
+        }
 
         onSettingsClick?.let { openSettings ->
             SettingsCornerButton(

--- a/app/src/main/java/com/codenames/frontend/ui/screens/JoinLobbyScreen.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/JoinLobbyScreen.kt
@@ -76,7 +76,7 @@ fun JoinlobbyScreen(
     val focusManager = LocalFocusManager.current
 
     val state by viewModel.state.collectAsState()
-    val username by sessionViewModel.userState.collectAsState()
+    val userState by sessionViewModel.userState.collectAsState()
 
     val joinEnabled = isLobbyIdValid(lobbyId)
 
@@ -92,7 +92,7 @@ fun JoinlobbyScreen(
         keyboardController?.hide()
         focusManager.clearFocus()
 
-        viewModel.joinLobby(username.username, lobbyId)
+        viewModel.joinLobby(userState.username, userState.userId, lobbyId)
     }
 
     Box(

--- a/app/src/main/java/com/codenames/frontend/ui/screens/JoinLobbyScreen.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/JoinLobbyScreen.kt
@@ -92,7 +92,7 @@ fun JoinlobbyScreen(
         keyboardController?.hide()
         focusManager.clearFocus()
 
-        viewModel.joinLobby(userState.username, userState.userId, lobbyId)
+        viewModel.joinLobby(userState.username, lobbyId)
     }
 
     Box(

--- a/app/src/main/java/com/codenames/frontend/ui/screens/LobbyScreen.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/LobbyScreen.kt
@@ -74,7 +74,7 @@ fun LobbyScreen(
     val connectionState by gameViewModel.connectionState.collectAsState()
 
     val onStartGame = {
-        viewModel.sendStartGame(userState.username)
+        viewModel.sendStartGame(userState.username, userState.userId)
     }
 
     LaunchedEffect(userState.userId) {
@@ -150,7 +150,7 @@ fun LobbyScreen(
                 gradient = blueGradient,
                 textColor = AppBlueLight,
                 title = "BLUE TEAM",
-                onRoleSelect = { viewModel.changeRole(it, userState.username) },
+                onRoleSelect = { viewModel.changeRole(it, userState.username, userState.userId) },
                 lobbyUiState = lobbyUiState,
             )
 
@@ -173,7 +173,7 @@ fun LobbyScreen(
                 gradient = redGradient,
                 textColor = AppRedLight,
                 title = "RED TEAM",
-                onRoleSelect = { viewModel.changeRole(it, userState.username) },
+                onRoleSelect = { viewModel.changeRole(it, userState.username, userState.userId) },
                 lobbyUiState = lobbyUiState,
             )
         }
@@ -409,7 +409,7 @@ fun GameSettingsColumn(
                         }
                     }
                 }
-                viewModel.leaveLobby(username = userState.username, onResult = onResult)
+                viewModel.leaveLobby(userId = userState.userId, onResult = onResult)
             },
             modifier =
                 Modifier

--- a/app/src/main/java/com/codenames/frontend/ui/screens/LobbyScreen.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/LobbyScreen.kt
@@ -40,7 +40,6 @@ import com.codenames.frontend.ui.roles.PlayerRoles
 import com.codenames.frontend.ui.theme.AppBackground
 import com.codenames.frontend.ui.theme.AppBlack
 import com.codenames.frontend.ui.theme.AppBlueLight
-import com.codenames.frontend.ui.theme.AppMutedDark
 import com.codenames.frontend.ui.theme.AppRedLight
 import com.codenames.frontend.ui.theme.AppWhite
 import com.codenames.frontend.ui.theme.LocalResponsiveDimensions
@@ -351,25 +350,13 @@ fun GameSettingsColumn(
                 text = "GAME SETTINGS",
                 color = AppWhite,
                 fontWeight = FontWeight.Bold,
-                fontSize = dimensions.smallFontSize,
+                fontSize = dimensions.buttonFontSize,
                 modifier = Modifier.padding(bottom = dimensions.itemSpacing),
             )
 
-            AppButton(
-                text = "TIMER: OFF",
-                onClick = { /* TODO: Timer Logik */ },
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .height(dimensions.secondaryButtonHeight)
-                        .padding(bottom = dimensions.smallSpacing),
-                style =
-                    AppButtonStyle(
-                        containerColor = AppMutedDark,
-                        contentColor = AppWhite,
-                        fontSize = dimensions.smallFontSize,
-                        lineHeight = dimensions.bodyFontSize,
-                    ),
+            Text(
+                text = "Upgrade to pro to see all features!",
+                color = AppWhite,
             )
         }
 

--- a/app/src/main/java/com/codenames/frontend/ui/screens/UserNameScreen.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/UserNameScreen.kt
@@ -38,7 +38,6 @@ import com.codenames.frontend.ui.theme.blueGradient
 import com.codenames.frontend.viewmodel.GameViewModel
 import com.codenames.frontend.viewmodel.LobbyViewModel
 import com.codenames.frontend.viewmodel.SessionViewModel
-import java.util.UUID
 
 @Suppress("ktlint:standard:function-naming")
 @Composable

--- a/app/src/main/java/com/codenames/frontend/ui/screens/UserNameScreen.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/UserNameScreen.kt
@@ -117,7 +117,6 @@ fun UserNameScreen(
                 onClick = {
                     if (username.isBlank()) return@AppButton
                     viewModel.setUsername(username)
-                    viewModel.setUserId(UUID.randomUUID()) // ONLY FOR TESTING!!!!
                     navController.navigate(Screen.Start.route)
                 },
                 modifier =

--- a/app/src/main/java/com/codenames/frontend/viewmodel/GameViewModel.kt
+++ b/app/src/main/java/com/codenames/frontend/viewmodel/GameViewModel.kt
@@ -232,6 +232,17 @@ class GameViewModel
             }
         }
 
+        fun resetGameState() {
+            viewModelScope.launch {
+                _uiState.update {
+                    GameState()
+                }
+            }
+            viewModelScope.launch {
+                handler.disconnect()
+            }
+        }
+
         private fun setConnectionError(error: Throwable) {
             _connectionState.value = ConnectionState.Error(ErrorMessageMapper.toUserMessage(error))
         }

--- a/app/src/main/java/com/codenames/frontend/viewmodel/GameViewModel.kt
+++ b/app/src/main/java/com/codenames/frontend/viewmodel/GameViewModel.kt
@@ -183,7 +183,7 @@ class GameViewModel
             if (lobbyCode != null && team != null && role != null) {
                 viewModelScope.launch {
                     try {
-                        gameRepository.sendRejoin(username, userId, lobbyCode, role, team)
+                        gameRepository.sendRejoin(username, userId, lobbyCode)
                     } catch (e: Exception) {
                         setConnectionError(e)
                     }

--- a/app/src/main/java/com/codenames/frontend/viewmodel/GameViewModel.kt
+++ b/app/src/main/java/com/codenames/frontend/viewmodel/GameViewModel.kt
@@ -237,8 +237,6 @@ class GameViewModel
                 _uiState.update {
                     GameState()
                 }
-            }
-            viewModelScope.launch {
                 handler.disconnect()
             }
         }

--- a/app/src/main/java/com/codenames/frontend/viewmodel/LobbyViewModel.kt
+++ b/app/src/main/java/com/codenames/frontend/viewmodel/LobbyViewModel.kt
@@ -20,13 +20,16 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import java.util.UUID
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
 
 @HiltViewModel
 class LobbyViewModel
     @Inject
     constructor(
         private val repository: LobbyRepository,
+        private val sessionViewModel: SessionViewModel
     ) : ViewModel() {
         private val _state = MutableStateFlow(LobbyUiState())
         val state: StateFlow<LobbyUiState> = _state
@@ -49,6 +52,9 @@ class LobbyViewModel
                     _state.update {
                         response.toLobbyState()
                     }
+                    if(response.uuid != null) {
+                        sessionViewModel.setUserId(UUID.fromString(response.uuid))
+                    }
                     startPolling(response.lobbyCode)
                 } catch (e: Exception) {
                     setError(e)
@@ -60,6 +66,7 @@ class LobbyViewModel
 
         fun joinLobby(
             username: String,
+            userId: UUID? = null,
             lobbyCode: String,
         ) {
             val inLobby = !_state.value.lobbyCode.isNullOrBlank()
@@ -72,13 +79,16 @@ class LobbyViewModel
                 setLoading(true)
 
                 try {
-                    val response = repository.joinLobby(username, lobbyCode)
+                    val response = repository.joinLobby(username, lobbyCode, userId)
 
                     _state.update {
                         response.toLobbyState()
                     }
                     updateUiState(_state.value.players)
                     startPolling(response.lobbyCode)
+                    if(response.uuid != null) {
+                        sessionViewModel.setUserId(UUID.fromString(response.uuid))
+                    }
                 } catch (e: Exception) {
                     setError(e)
                 } finally {
@@ -88,7 +98,7 @@ class LobbyViewModel
         }
 
         fun leaveLobby(
-            username: String,
+            userId: UUID,
             onResult: (Boolean) -> Unit,
         ) {
             val lobbyCode = _state.value.lobbyCode
@@ -104,7 +114,7 @@ class LobbyViewModel
                 setLoading(true)
 
                 try {
-                    val response = repository.leaveLobby(lobbyCode, username)
+                    val response = repository.leaveLobby(lobbyCode, userId)
                     _state.update {
                         response.toLobbyState()
                     }
@@ -126,6 +136,7 @@ class LobbyViewModel
             role: Role,
             team: Team,
             username: String,
+            userId: UUID
         ) {
             val lobbyCode = _state.value.lobbyCode
             if (lobbyCode.isNullOrBlank()) {
@@ -137,7 +148,7 @@ class LobbyViewModel
                 setLoading(true)
 
                 try {
-                    val response = repository.changeRole(username, lobbyCode, role, team)
+                    val response = repository.changeRole(username, userId, lobbyCode, role, team)
 
                     _state.update {
                         response.toLobbyState()
@@ -154,12 +165,13 @@ class LobbyViewModel
         fun changeRole(
             role: PlayerRoles,
             username: String,
+            userId: UUID
         ) {
             when (role) {
-                PlayerRoles.BLUE_SPYMASTER -> changeRole(role = Role.SPYMASTER, team = Team.BLUE, username = username)
-                PlayerRoles.RED_SPYMASTER -> changeRole(role = Role.SPYMASTER, team = Team.RED, username = username)
-                PlayerRoles.BLUE_OPERATIVE -> changeRole(role = Role.OPERATIVE, team = Team.BLUE, username = username)
-                PlayerRoles.RED_OPERATIVE -> changeRole(role = Role.OPERATIVE, team = Team.RED, username = username)
+                PlayerRoles.BLUE_SPYMASTER -> changeRole(role = Role.SPYMASTER, team = Team.BLUE, username = username, userId)
+                PlayerRoles.RED_SPYMASTER -> changeRole(role = Role.SPYMASTER, team = Team.RED, username = username, userId)
+                PlayerRoles.BLUE_OPERATIVE -> changeRole(role = Role.OPERATIVE, team = Team.BLUE, username = username, userId)
+                PlayerRoles.RED_OPERATIVE -> changeRole(role = Role.OPERATIVE, team = Team.RED, username = username, userId)
                 else -> setError("Invalid role")
             }
         }
@@ -212,13 +224,13 @@ class LobbyViewModel
             return player.isHost
         }
 
-        fun sendStartGame(username: String) {
+        fun sendStartGame(username: String, userId: UUID) {
             val lobbyCode = _state.value.lobbyCode.orEmpty()
-            if (!username.isBlank() && !lobbyCode.isEmpty() && getIsHost(username)) {
+            if (!username.isBlank() && lobbyCode.isNotEmpty() && getIsHost(username)) {
                 viewModelScope.launch {
                     try {
                         setLoading(true)
-                        val response = repository.sendStartGame(lobbyCode, username)
+                        val response = repository.sendStartGame(lobbyCode, userId)
                         _state.update {
                             response.toLobbyState()
                         }
@@ -297,7 +309,7 @@ class LobbyViewModel
                             return@launch
                         }
 
-                        delay(pollingTime)
+                        delay(pollingTime.milliseconds)
                     }
                 }
         }

--- a/app/src/main/java/com/codenames/frontend/viewmodel/LobbyViewModel.kt
+++ b/app/src/main/java/com/codenames/frontend/viewmodel/LobbyViewModel.kt
@@ -24,6 +24,8 @@ import java.util.UUID
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds
 
+private const val ID_NOT_FOUND = "No valid ID found."
+
 @HiltViewModel
 class LobbyViewModel
     @Inject
@@ -98,7 +100,7 @@ class LobbyViewModel
         }
 
         fun leaveLobby(
-            userId: UUID,
+            userId: UUID?,
             onResult: (Boolean) -> Unit,
         ) {
             val lobbyCode = _state.value.lobbyCode
@@ -107,6 +109,10 @@ class LobbyViewModel
             if (lobbyCode.isNullOrBlank()) {
                 setError("Not in a lobby, leaving not possible")
                 onResult(successful)
+                return
+            }
+            if(userId == null) {
+                setError(ID_NOT_FOUND)
                 return
             }
 
@@ -136,11 +142,15 @@ class LobbyViewModel
             role: Role,
             team: Team,
             username: String,
-            userId: UUID
+            userId: UUID?
         ) {
             val lobbyCode = _state.value.lobbyCode
             if (lobbyCode.isNullOrBlank()) {
                 setError("Not in a Lobby")
+                return
+            }
+            if(userId == null) {
+                setError(ID_NOT_FOUND)
                 return
             }
 
@@ -165,7 +175,7 @@ class LobbyViewModel
         fun changeRole(
             role: PlayerRoles,
             username: String,
-            userId: UUID
+            userId: UUID?
         ) {
             when (role) {
                 PlayerRoles.BLUE_SPYMASTER -> changeRole(role = Role.SPYMASTER, team = Team.BLUE, username = username, userId)
@@ -224,8 +234,12 @@ class LobbyViewModel
             return player.isHost
         }
 
-        fun sendStartGame(username: String, userId: UUID) {
+        fun sendStartGame(username: String, userId: UUID?) {
             val lobbyCode = _state.value.lobbyCode.orEmpty()
+            if(userId == null) {
+                setError(ID_NOT_FOUND)
+                return
+            }
             if (!username.isBlank() && lobbyCode.isNotEmpty() && getIsHost(username)) {
                 viewModelScope.launch {
                     try {

--- a/app/src/main/java/com/codenames/frontend/viewmodel/LobbyViewModel.kt
+++ b/app/src/main/java/com/codenames/frontend/viewmodel/LobbyViewModel.kt
@@ -32,7 +32,7 @@ class LobbyViewModel
     @Inject
     constructor(
         private val repository: LobbyRepository,
-        private val sessionRepository: SessionRepository
+        private val sessionRepository: SessionRepository,
     ) : ViewModel() {
         private val _state = MutableStateFlow(LobbyUiState())
         val state: StateFlow<LobbyUiState> = _state
@@ -54,7 +54,7 @@ class LobbyViewModel
                     _state.update {
                         response.toLobbyState()
                     }
-                    if(response.uuid != null) sessionRepository.saveUser(username, UUID.fromString(response.uuid))
+                    if (response.uuid != null) sessionRepository.saveUser(username, UUID.fromString(response.uuid))
                     startPolling(response.lobbyCode)
                 } catch (e: Exception) {
                     setError(e)
@@ -85,7 +85,7 @@ class LobbyViewModel
                     _state.update {
                         response.toLobbyState()
                     }
-                    if(response.uuid != null)  sessionRepository.saveUser(username, UUID.fromString(response.uuid))
+                    if (response.uuid != null) sessionRepository.saveUser(username, UUID.fromString(response.uuid))
                     updateUiState(_state.value.players)
                     startPolling(response.lobbyCode)
                 } catch (e: Exception) {
@@ -108,7 +108,7 @@ class LobbyViewModel
                 onResult(successful)
                 return
             }
-            if(userId == null) {
+            if (userId == null) {
                 setError(ID_NOT_FOUND)
                 return
             }
@@ -139,14 +139,14 @@ class LobbyViewModel
             role: Role,
             team: Team,
             username: String,
-            userId: UUID?
+            userId: UUID?,
         ) {
             val lobbyCode = _state.value.lobbyCode
             if (lobbyCode.isNullOrBlank()) {
                 setError("Not in a Lobby")
                 return
             }
-            if(userId == null) {
+            if (userId == null) {
                 setError(ID_NOT_FOUND)
                 return
             }
@@ -172,7 +172,7 @@ class LobbyViewModel
         fun changeRole(
             role: PlayerRoles,
             username: String,
-            userId: UUID?
+            userId: UUID?,
         ) {
             when (role) {
                 PlayerRoles.BLUE_SPYMASTER -> changeRole(role = Role.SPYMASTER, team = Team.BLUE, username = username, userId)
@@ -220,9 +220,12 @@ class LobbyViewModel
             return player.isHost
         }
 
-        fun sendStartGame(username: String, userId: UUID?) {
+        fun sendStartGame(
+            username: String,
+            userId: UUID?,
+        ) {
             val lobbyCode = _state.value.lobbyCode.orEmpty()
-            if(userId == null) {
+            if (userId == null) {
                 setError(ID_NOT_FOUND)
                 return
             }

--- a/app/src/main/java/com/codenames/frontend/viewmodel/LobbyViewModel.kt
+++ b/app/src/main/java/com/codenames/frontend/viewmodel/LobbyViewModel.kt
@@ -258,7 +258,7 @@ class LobbyViewModel
             }
         }
 
-        private fun cleanup() {
+        fun cleanup() {
             _state.update {
                 it.copy(
                     lobbyCode = null,
@@ -269,6 +269,8 @@ class LobbyViewModel
                     redSpymasters = emptyList(),
                 )
             }
+            stopPolling()
+            clearError()
         }
 
         private fun updateUiState(players: List<Player>) {

--- a/app/src/main/java/com/codenames/frontend/viewmodel/LobbyViewModel.kt
+++ b/app/src/main/java/com/codenames/frontend/viewmodel/LobbyViewModel.kt
@@ -55,7 +55,7 @@ class LobbyViewModel
                         response.toLobbyState()
                     }
                     if(response.uuid != null) {
-                        sessionViewModel.setUserId(UUID.fromString(response.uuid))
+                        sessionViewModel.persistUserId(UUID.fromString(response.uuid))
                     }
                     startPolling(response.lobbyCode)
                 } catch (e: Exception) {
@@ -89,7 +89,7 @@ class LobbyViewModel
                     updateUiState(_state.value.players)
                     startPolling(response.lobbyCode)
                     if(response.uuid != null) {
-                        sessionViewModel.setUserId(UUID.fromString(response.uuid))
+                        sessionViewModel.persistUserId(UUID.fromString(response.uuid))
                     }
                 } catch (e: Exception) {
                     setError(e)

--- a/app/src/main/java/com/codenames/frontend/viewmodel/LobbyViewModel.kt
+++ b/app/src/main/java/com/codenames/frontend/viewmodel/LobbyViewModel.kt
@@ -48,7 +48,7 @@ class LobbyViewModel
             }
             viewModelScope.launch {
                 setLoading(true)
-
+                sessionRepository.clearUserId()
                 try {
                     val response = repository.createLobby(username)
                     _state.update {
@@ -66,7 +66,6 @@ class LobbyViewModel
 
         fun joinLobby(
             username: String,
-            userId: UUID? = null,
             lobbyCode: String,
         ) {
             val inLobby = !_state.value.lobbyCode.isNullOrBlank()
@@ -78,8 +77,10 @@ class LobbyViewModel
             viewModelScope.launch {
                 setLoading(true)
 
+                sessionRepository.clearUserId()
+
                 try {
-                    val response = repository.joinLobby(username, lobbyCode, userId)
+                    val response = repository.joinLobby(username, lobbyCode)
 
                     _state.update {
                         response.toLobbyState()

--- a/app/src/main/java/com/codenames/frontend/viewmodel/LobbyViewModel.kt
+++ b/app/src/main/java/com/codenames/frontend/viewmodel/LobbyViewModel.kt
@@ -11,6 +11,7 @@ import com.codenames.frontend.data.model.enums.Role
 import com.codenames.frontend.data.model.enums.Team
 import com.codenames.frontend.data.model.toLobbyState
 import com.codenames.frontend.data.repository.LobbyRepository
+import com.codenames.frontend.data.repository.SessionRepository
 import com.codenames.frontend.ui.roles.PlayerRoles
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
@@ -31,7 +32,7 @@ class LobbyViewModel
     @Inject
     constructor(
         private val repository: LobbyRepository,
-        private val sessionViewModel: SessionViewModel
+        private val sessionRepository: SessionRepository
     ) : ViewModel() {
         private val _state = MutableStateFlow(LobbyUiState())
         val state: StateFlow<LobbyUiState> = _state
@@ -50,13 +51,10 @@ class LobbyViewModel
 
                 try {
                     val response = repository.createLobby(username)
-
                     _state.update {
                         response.toLobbyState()
                     }
-                    if(response.uuid != null) {
-                        sessionViewModel.persistUserId(UUID.fromString(response.uuid))
-                    }
+                    if(response.uuid != null) sessionRepository.saveUser(username, UUID.fromString(response.uuid))
                     startPolling(response.lobbyCode)
                 } catch (e: Exception) {
                     setError(e)
@@ -86,11 +84,9 @@ class LobbyViewModel
                     _state.update {
                         response.toLobbyState()
                     }
+                    if(response.uuid != null)  sessionRepository.saveUser(username, UUID.fromString(response.uuid))
                     updateUiState(_state.value.players)
                     startPolling(response.lobbyCode)
-                    if(response.uuid != null) {
-                        sessionViewModel.persistUserId(UUID.fromString(response.uuid))
-                    }
                 } catch (e: Exception) {
                     setError(e)
                 } finally {

--- a/app/src/main/java/com/codenames/frontend/viewmodel/SessionViewModel.kt
+++ b/app/src/main/java/com/codenames/frontend/viewmodel/SessionViewModel.kt
@@ -41,16 +41,16 @@ class SessionViewModel
         }
 
         fun persistLobbyState(
-                lobbyCode: String,
-                role: Role,
-                team: Team,
-            ) {
+            lobbyCode: String,
+            role: Role,
+            team: Team,
+        ) {
             viewModelScope.launch {
                 sessionRepository.saveLobby(
                     lobbyCode,
                     role,
                     team,
-                    )
+                )
             }
         }
 
@@ -67,7 +67,7 @@ class SessionViewModel
             viewModelScope.launch {
                 sessionRepository.saveUser(
                     _userState.value.username,
-                    userId
+                    userId,
                 )
             }
         }

--- a/app/src/main/java/com/codenames/frontend/viewmodel/SessionViewModel.kt
+++ b/app/src/main/java/com/codenames/frontend/viewmodel/SessionViewModel.kt
@@ -40,25 +40,17 @@ class SessionViewModel
             }
         }
 
-        fun setUserId(userId: UUID) {
-            _userState.update {
-                it.copy(
-                    userId = userId,
-                )
-            }
-        }
-
         fun persistLobbyState(
-            lobbyCode: String,
-            role: Role,
-            team: Team,
-        ) {
+                lobbyCode: String,
+                role: Role,
+                team: Team,
+            ) {
             viewModelScope.launch {
                 sessionRepository.saveLobby(
                     lobbyCode,
                     role,
                     team,
-                )
+                    )
             }
         }
 
@@ -67,6 +59,15 @@ class SessionViewModel
                 sessionRepository.saveUser(
                     _userState.value.username,
                     _userState.value.userId ?: return@launch,
+                )
+            }
+        }
+
+        fun persistUserId(userId: UUID) {
+            viewModelScope.launch {
+                sessionRepository.saveUser(
+                    _userState.value.username,
+                    userId
                 )
             }
         }

--- a/app/src/test/java/com/codenames/frontend/data/repository/GameRepositoryTest.kt
+++ b/app/src/test/java/com/codenames/frontend/data/repository/GameRepositoryTest.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
+import java.util.UUID
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class GameRepositoryTest {
@@ -95,5 +96,20 @@ class GameRepositoryTest {
             gameRepository.passTurn(lobbyCode, currentTurn)
 
             coVerify { webSocketHandler.passTurn(any()) }
+        }
+
+    @Test
+    fun testSendRejoin() =
+        runTest {
+            val username = "User"
+            val lobbyCode = "ABCDE"
+            val userId = UUID.randomUUID()
+            coEvery { webSocketHandler.sendReconnectMessage(any()) } just Runs
+
+            gameRepository.sendRejoin(username, userId, lobbyCode)
+
+            coVerify {
+                webSocketHandler.sendReconnectMessage(any())
+            }
         }
 }

--- a/app/src/test/java/com/codenames/frontend/data/repository/LobbyRepositoryTest.kt
+++ b/app/src/test/java/com/codenames/frontend/data/repository/LobbyRepositoryTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import java.util.UUID
 import kotlin.test.assertFailsWith
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -66,14 +67,15 @@ class LobbyRepositoryTest {
         runTest {
             val username = "Max"
             val lobbyCode = "1234"
+            val userId = UUID.randomUUID()
 
             val response = LobbyResponse(lobbyCode, emptyList(), false)
 
-            coEvery { api.leaveLobby(username, lobbyCode) } returns response
+            coEvery { api.leaveLobby(lobbyCode = lobbyCode, uuid = userId.toString()) } returns response
 
-            val result = repository.leaveLobby(username, lobbyCode)
+            val result = repository.leaveLobby(lobbyCode, userId)
 
-            coVerify { api.leaveLobby(username, lobbyCode) }
+            coVerify { api.leaveLobby(lobbyCode, userId.toString()) }
             assertEquals(response, result)
         }
 
@@ -97,12 +99,13 @@ class LobbyRepositoryTest {
             val lobbyCode = "1234"
             val role = Role.OPERATIVE
             val team = Team.RED
+            val userId = UUID.randomUUID()
 
             val response = LobbyResponse(lobbyCode, emptyList(), false)
 
             coEvery { api.changeRole(eq(lobbyCode), any()) } returns response
 
-            repository.changeRole(username, lobbyCode, role, team)
+            repository.changeRole(username, userId, lobbyCode, role, team)
 
             coVerify {
                 api.changeRole(
@@ -133,6 +136,7 @@ class LobbyRepositoryTest {
         runTest {
             val lobbyCode = "ABCDE"
             val username = "Test"
+            val userId = UUID.randomUUID()
             val list =
                 listOf(
                     PlayerDto(
@@ -145,7 +149,7 @@ class LobbyRepositoryTest {
 
             coEvery { api.startGame(any(), any()) } returns LobbyResponse(lobbyCode, list, false)
 
-            val response = repository.sendStartGame(lobbyCode, username)
+            val response = repository.sendStartGame(lobbyCode, userId)
 
             coVerify { api.startGame(any(), any()) }
             assertEquals(response.lobbyCode, lobbyCode)

--- a/app/src/test/java/com/codenames/frontend/data/repository/SessionRepositoryTest.kt
+++ b/app/src/test/java/com/codenames/frontend/data/repository/SessionRepositoryTest.kt
@@ -64,4 +64,14 @@ class SessionRepositoryTest {
                 dataStore.clearSessionData()
             }
         }
+
+    @Test
+    fun `clearUserId delegates to datastore`() =
+        runTest {
+            repository.clearUserId()
+
+            coVerify {
+                dataStore.removeUserId()
+            }
+        }
 }

--- a/app/src/test/java/com/codenames/frontend/network/websocket/GameWebSocketControllerTest.kt
+++ b/app/src/test/java/com/codenames/frontend/network/websocket/GameWebSocketControllerTest.kt
@@ -18,6 +18,7 @@ import org.hildan.krossbow.stomp.conversions.kxserialization.convertAndSend
 import org.hildan.krossbow.stomp.conversions.kxserialization.subscribe
 import org.junit.Before
 import org.junit.Test
+import java.util.UUID
 
 class GameWebSocketControllerTest {
     private lateinit var wsClient: GameWebSocketController
@@ -63,7 +64,7 @@ class GameWebSocketControllerTest {
     @Test
     fun testSendReconnectMessageSendsMessage() =
         runTest {
-            val msg = WebSocketJoinMessage("name", "1234")
+            val msg = WebSocketJoinMessage("name", "1234", UUID.randomUUID().toString())
 
             wsClient.sendReconnectMessage(msg)
 

--- a/app/src/test/java/com/codenames/frontend/viewmodel/GameViewModelTest.kt
+++ b/app/src/test/java/com/codenames/frontend/viewmodel/GameViewModelTest.kt
@@ -568,7 +568,7 @@ class GameViewModelTest {
     fun testSendRejoinMessage_sendsMessage() =
         runTest {
             coEvery {
-                gameRepository.sendRejoin(any(), any(), any(), any(), any())
+                gameRepository.sendRejoin(any(), any(), any())
             } just Runs
 
             val rejoinState = RejoinState.Available(SessionState(lobbyCode, Role.OPERATIVE, Team.RED))
@@ -578,7 +578,7 @@ class GameViewModelTest {
             advanceUntilIdle()
 
             coVerify {
-                gameRepository.sendRejoin(any(), any(), any(), any(), any())
+                gameRepository.sendRejoin(any(), any(), any())
             }
         }
 
@@ -586,7 +586,7 @@ class GameViewModelTest {
     fun testSendRejoinMessage_ignoresWithoutRejoinState() =
         runTest {
             coEvery {
-                gameRepository.sendRejoin(any(), any(), any(), any(), any())
+                gameRepository.sendRejoin(any(), any(), any())
             } just Runs
 
             val rejoinState = null
@@ -596,7 +596,7 @@ class GameViewModelTest {
             advanceUntilIdle()
 
             coVerify(exactly = 0) {
-                gameRepository.sendRejoin(any(), any(), any(), any(), any())
+                gameRepository.sendRejoin(any(), any(), any())
             }
         }
 
@@ -604,7 +604,7 @@ class GameViewModelTest {
     fun testSendRejoinMessage_ignoresNullValuesInRejoinState() =
         runTest {
             coEvery {
-                gameRepository.sendRejoin(any(), any(), any(), any(), any())
+                gameRepository.sendRejoin(any(), any(), any())
             } just Runs
 
             val rejoinState = RejoinState.Available(SessionState(null, null, null))
@@ -614,7 +614,7 @@ class GameViewModelTest {
             advanceUntilIdle()
 
             coVerify(exactly = 0) {
-                gameRepository.sendRejoin(any(), any(), any(), any(), any())
+                gameRepository.sendRejoin(any(), any(), any())
             }
         }
 

--- a/app/src/test/java/com/codenames/frontend/viewmodel/GameViewModelTest.kt
+++ b/app/src/test/java/com/codenames/frontend/viewmodel/GameViewModelTest.kt
@@ -656,6 +656,29 @@ class GameViewModelTest {
         }
 
     @Test
+    fun resetGameState_resetsGameState() =
+        runTest {
+            mockkStatic(Log::class)
+            every { Log.d(any(), any()) } returns 0
+
+            coEvery { client.disconnect() } just Runs
+
+            viewModel.handleMessage(testMessage)
+
+            advanceUntilIdle()
+
+            viewModel.resetGameState()
+
+            advanceUntilIdle()
+
+            val compareMessage = GameState()
+
+            assertEquals(compareMessage.cards, viewModel.uiState.value.cards)
+            assertEquals(compareMessage.winner, viewModel.uiState.value.winner)
+            assertEquals(compareMessage.currentTurn, viewModel.uiState.value.currentTurn)
+        }
+
+    @Test
     fun requestCheat_callsRepository() =
         runTest {
             viewModel.requestCheat(

--- a/app/src/test/java/com/codenames/frontend/viewmodel/LobbyViewModelTest.kt
+++ b/app/src/test/java/com/codenames/frontend/viewmodel/LobbyViewModelTest.kt
@@ -5,12 +5,15 @@ import com.codenames.frontend.data.model.enums.ChatTab
 import com.codenames.frontend.data.model.enums.Role
 import com.codenames.frontend.data.model.enums.Team
 import com.codenames.frontend.data.repository.LobbyRepository
+import com.codenames.frontend.data.repository.SessionRepository
 import com.codenames.frontend.network.dto.LobbyResponse
 import com.codenames.frontend.network.dto.PlayerDto
 import com.codenames.frontend.ui.roles.PlayerRoles
+import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.spyk
@@ -30,14 +33,19 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.util.UUID
+import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class LobbyViewModelTest {
     private val dispatcher = StandardTestDispatcher()
+    val repository = mockk<LobbyRepository>()
+    val sessionRepository = mockk<SessionRepository>()
 
     @Before
     fun setup() {
         Dispatchers.setMain(dispatcher)
+
     }
 
     @After
@@ -48,8 +56,6 @@ class LobbyViewModelTest {
     @Test
     fun testCreateLobby_success() =
         runTest {
-            val repository = mockk<LobbyRepository>()
-
             val response =
                 LobbyResponse(
                     lobbyCode = "1234",
@@ -59,12 +65,13 @@ class LobbyViewModelTest {
 
             coEvery { repository.createLobby("User") } returns response
             coEvery { repository.getLobbyInfo(any()) } returns response
+            coEvery { sessionRepository.clearUserId() } just Runs
 
-            val viewModel = LobbyViewModel(repository)
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             viewModel.createLobby("User")
 
-            advanceTimeBy(2000)
+            advanceTimeBy(2000.milliseconds)
 
             viewModel.stopPollingForTest()
 
@@ -78,15 +85,14 @@ class LobbyViewModelTest {
     @Test
     fun testCreateLobby_error() =
         runTest {
-            val repository = mockk<LobbyRepository>()
-
             coEvery { repository.createLobby(any()) } throws RuntimeException("Network error")
+            coEvery { sessionRepository.clearUserId() } just Runs
 
-            val viewModel = LobbyViewModel(repository)
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             viewModel.createLobby("Max")
 
-            advanceTimeBy(2000)
+            advanceTimeBy(2000.milliseconds)
 
             viewModel.stopPollingForTest()
 
@@ -99,7 +105,6 @@ class LobbyViewModelTest {
     @Test
     fun testJoinLobby_success() =
         runTest {
-            val repository = mockk<LobbyRepository>()
 
             val response =
                 LobbyResponse(
@@ -116,11 +121,13 @@ class LobbyViewModelTest {
                     false,
                 )
 
-            val viewModel = LobbyViewModel(repository)
+            coEvery { sessionRepository.clearUserId() } just Runs
+
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             viewModel.joinLobby("User", "1234")
 
-            advanceTimeBy(2000)
+            advanceTimeBy(2000.milliseconds)
 
             viewModel.stopPollingForTest()
 
@@ -134,15 +141,15 @@ class LobbyViewModelTest {
     @Test
     fun testJoinLobby_error() =
         runTest {
-            val repository = mockk<LobbyRepository>()
 
             coEvery { repository.joinLobby(any(), any()) } throws RuntimeException("Network error")
+            coEvery { sessionRepository.clearUserId() } just Runs
 
-            val viewModel = LobbyViewModel(repository)
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             viewModel.joinLobby("Max", "1234")
 
-            advanceTimeBy(2000)
+            advanceTimeBy(2000.milliseconds)
 
             viewModel.stopPollingForTest()
 
@@ -155,7 +162,6 @@ class LobbyViewModelTest {
     @Test
     fun testLeaveLobby_success() =
         runTest {
-            val repository = mockk<LobbyRepository>()
 
             val response =
                 LobbyResponse(
@@ -171,17 +177,20 @@ class LobbyViewModelTest {
                     false,
                 )
 
+            val userId = UUID.randomUUID()
+
             coEvery { repository.joinLobby("User", "1234") } returns response
             coEvery { repository.getLobbyInfo(any()) } returns response
-            coEvery { repository.leaveLobby("1234", "User") } returns response2
+            coEvery { repository.leaveLobby("1234", userId) } returns response2
+            coEvery { sessionRepository.clearUserId() } just Runs
 
-            val viewModel = LobbyViewModel(repository)
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             viewModel.joinLobby("User", "1234")
-            advanceTimeBy(2000)
-            viewModel.leaveLobby("User", onResult = {})
+            advanceTimeBy(2000.milliseconds)
+            viewModel.leaveLobby(userId = userId , onResult = {})
 
-            advanceTimeBy(2000)
+            advanceTimeBy(2000.milliseconds)
 
             viewModel.stopPollingForTest()
 
@@ -195,7 +204,6 @@ class LobbyViewModelTest {
     @Test
     fun testLeaveLobby_error() =
         runTest {
-            val repository = mockk<LobbyRepository>()
 
             val response =
                 LobbyResponse(
@@ -203,19 +211,21 @@ class LobbyViewModelTest {
                     playerList = listOf(PlayerDto("User", null, Team.RED, true)),
                     false,
                 )
+            val userID = UUID.randomUUID()
 
             coEvery { repository.joinLobby("User", "1234") } returns response
             coEvery { repository.leaveLobby(any(), any()) } throws RuntimeException("Network error")
+            coEvery { sessionRepository.clearUserId() } just Runs
 
-            val viewModel = LobbyViewModel(repository)
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             viewModel.joinLobby("User", "1234")
 
-            advanceTimeBy(2000)
+            advanceTimeBy(2000.milliseconds)
 
-            viewModel.leaveLobby("User", onResult = {})
+            viewModel.leaveLobby(userId = userID, onResult = {})
 
-            advanceTimeBy(2000)
+            advanceTimeBy(2000.milliseconds)
 
             viewModel.stopPollingForTest()
 
@@ -228,10 +238,10 @@ class LobbyViewModelTest {
     @Test
     fun testChangeRole_success() =
         runTest {
-            val repository = mockk<LobbyRepository>()
 
             val newRole = Role.OPERATIVE
             val newTeam = Team.RED
+            val username = "User"
 
             val response =
                 LobbyResponse(
@@ -246,21 +256,23 @@ class LobbyViewModelTest {
                     playerList = listOf(PlayerDto("User", newRole, newTeam, true)),
                     false,
                 )
+            val userId = UUID.randomUUID()
 
             coEvery { repository.joinLobby("User", "1234") } returns response
             coEvery { repository.getLobbyInfo(any()) } returns response
-            coEvery { repository.changeRole("User", "1234", newRole, newTeam) } returns response2
+            coEvery { repository.changeRole("User", userId, "1234", newRole, newTeam) } returns response2
+            coEvery { sessionRepository.clearUserId() } just Runs
 
-            val viewModel = LobbyViewModel(repository)
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             viewModel.joinLobby("User", "1234")
 
-            advanceTimeBy(2000)
+            advanceTimeBy(2000.milliseconds)
 
-            viewModel.changeRole(newRole, newTeam, "User")
+            viewModel.changeRole(newRole, newTeam, username, userId)
             viewModel.stopPollingForTest()
 
-            advanceTimeBy(2000)
+            advanceTimeBy(2000.milliseconds)
 
             val state = viewModel.state.value
 
@@ -274,7 +286,6 @@ class LobbyViewModelTest {
     @Test
     fun testChangeRole_error() =
         runTest {
-            val repository = mockk<LobbyRepository>()
 
             val response =
                 LobbyResponse(
@@ -290,18 +301,21 @@ class LobbyViewModelTest {
                     any(),
                     any(),
                     any(),
+                    any()
                 )
             } throws RuntimeException("Network error")
 
-            val viewModel = LobbyViewModel(repository)
+            coEvery { sessionRepository.clearUserId() } just Runs
+
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             viewModel.joinLobby("User", "1234")
 
-            advanceTimeBy(2000)
+            advanceTimeBy(2000.milliseconds)
 
-            viewModel.changeRole(Role.OPERATIVE, Team.RED, "User")
+            viewModel.changeRole(Role.OPERATIVE, Team.RED, "User", UUID.randomUUID())
 
-            advanceTimeBy(2000)
+            advanceTimeBy(2000.milliseconds)
 
             viewModel.stopPollingForTest()
 
@@ -314,15 +328,15 @@ class LobbyViewModelTest {
     @Test
     fun testSetError_WithEmptyValue() =
         runTest {
-            val repository = mockk<LobbyRepository>()
 
             coEvery { repository.createLobby(any()) } throws RuntimeException("")
+            coEvery { sessionRepository.clearUserId() } just Runs
 
-            val viewModel = LobbyViewModel(repository)
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             viewModel.createLobby("Max")
 
-            advanceTimeBy(2000)
+            advanceTimeBy(2000.milliseconds)
 
             viewModel.stopPollingForTest()
 
@@ -335,15 +349,15 @@ class LobbyViewModelTest {
     @Test
     fun testSetError_WithNullValue() =
         runTest {
-            val repository = mockk<LobbyRepository>()
 
             coEvery { repository.createLobby(any()) } throws RuntimeException()
+            coEvery { sessionRepository.clearUserId() } just Runs
 
-            val viewModel = LobbyViewModel(repository)
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             viewModel.createLobby("Max")
 
-            advanceTimeBy(2000)
+            advanceTimeBy(2000.milliseconds)
 
             viewModel.stopPollingForTest()
 
@@ -357,7 +371,6 @@ class LobbyViewModelTest {
     @Test
     fun testPolling_callsRepositoryRepeatedly() =
         runTest {
-            val repository = mockk<LobbyRepository>()
 
             coEvery { repository.getLobbyInfo(any()) } returns
                 LobbyResponse(
@@ -366,12 +379,11 @@ class LobbyViewModelTest {
                     false,
                 )
 
-            val viewModel = LobbyViewModel(repository)
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             viewModel.startPollingForTest("1234")
 
-            advanceTimeBy(2000)
-            advanceTimeBy(2000)
+            advanceTimeBy(4000.milliseconds)
 
             viewModel.stopPollingForTest()
 
@@ -383,20 +395,17 @@ class LobbyViewModelTest {
     @Test
     fun testPolling_stateIsUpdated() =
         runTest {
-            val repository = mockk<LobbyRepository>()
-
             coEvery { repository.getLobbyInfo(any()) } returnsMany
                 listOf(
                     LobbyResponse("1", emptyList(), false),
                     LobbyResponse("2", emptyList(), false),
                 )
 
-            val viewModel = LobbyViewModel(repository)
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             viewModel.startPollingForTest("1234")
 
-            advanceTimeBy(2000)
-            advanceTimeBy(2000)
+            advanceTimeBy(4000.milliseconds)
 
             viewModel.stopPollingForTest()
 
@@ -406,7 +415,6 @@ class LobbyViewModelTest {
     @Test
     fun testPolling_doesNotStartTwice() =
         runTest {
-            val repository = mockk<LobbyRepository>()
 
             coEvery { repository.getLobbyInfo("1234") } returns
                 LobbyResponse(
@@ -415,16 +423,15 @@ class LobbyViewModelTest {
                     false,
                 )
 
-            val viewModel = LobbyViewModel(repository)
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             viewModel.startPollingForTest("1234")
 
-            advanceTimeBy(2000)
-            advanceTimeBy(2000)
+            advanceTimeBy(4000.milliseconds)
 
             viewModel.startPollingForTest("2345")
 
-            advanceTimeBy(2000)
+            advanceTimeBy(2000.milliseconds)
 
             viewModel.stopPollingForTest()
 
@@ -437,7 +444,6 @@ class LobbyViewModelTest {
     @Test
     fun testCreateLobby_alreadyInLobby() =
         runTest {
-            val repository = mockk<LobbyRepository>()
 
             val response =
                 LobbyResponse(
@@ -447,8 +453,9 @@ class LobbyViewModelTest {
                 )
 
             coEvery { repository.createLobby("User") } returns response
+            coEvery { sessionRepository.clearUserId() } just Runs
 
-            val viewModel = LobbyViewModel(repository)
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             viewModel.createLobby("User")
 
@@ -468,8 +475,6 @@ class LobbyViewModelTest {
     @Test
     fun testJoinLobby_alreadyInLobby() =
         runTest {
-            val repository = mockk<LobbyRepository>()
-
             val response =
                 LobbyResponse(
                     lobbyCode = "1234",
@@ -478,8 +483,9 @@ class LobbyViewModelTest {
                 )
 
             coEvery { repository.createLobby("User") } returns response
+            coEvery { sessionRepository.clearUserId() } just Runs
 
-            val viewModel = LobbyViewModel(repository)
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             viewModel.createLobby("User")
 
@@ -499,11 +505,10 @@ class LobbyViewModelTest {
     @Test
     fun testLeaveLobby_notInLobby() =
         runTest {
-            val repository = mockk<LobbyRepository>()
 
-            val viewModel = LobbyViewModel(repository)
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
-            viewModel.leaveLobby("User", onResult = {})
+            viewModel.leaveLobby(UUID.randomUUID(), onResult = {})
 
             advanceUntilIdle()
 
@@ -517,11 +522,9 @@ class LobbyViewModelTest {
     @Test
     fun testChangeRoles_notInLobby() =
         runTest {
-            val repository = mockk<LobbyRepository>()
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
-            val viewModel = LobbyViewModel(repository)
-
-            viewModel.changeRole(Role.OPERATIVE, Team.RED, "User")
+            viewModel.changeRole(Role.OPERATIVE, Team.RED, "User", UUID.randomUUID())
 
             advanceUntilIdle()
 
@@ -534,32 +537,29 @@ class LobbyViewModelTest {
 
     @Test
     fun changeRole_DelegatesCorrectly1() {
-        val repository = mockk<LobbyRepository>()
-        val viewModel = spyk<LobbyViewModel>(LobbyViewModel(repository), recordPrivateCalls = true)
-        viewModel.changeRole(PlayerRoles.BLUE_SPYMASTER, "Alice")
+        val viewModel = spyk<LobbyViewModel>(LobbyViewModel(repository, sessionRepository), recordPrivateCalls = true)
+        viewModel.changeRole(PlayerRoles.BLUE_SPYMASTER, "Alice", UUID.randomUUID())
 
         verify {
-            viewModel.changeRole(Role.SPYMASTER, Team.BLUE, "Alice")
+            viewModel.changeRole(Role.SPYMASTER, Team.BLUE, "Alice", any())
         }
     }
 
     @Test
     fun changeRole_DelegatesCorrectly2() {
-        val repository = mockk<LobbyRepository>()
-        val viewModel = spyk<LobbyViewModel>(LobbyViewModel(repository), recordPrivateCalls = true)
+        val viewModel = spyk<LobbyViewModel>(LobbyViewModel(repository, sessionRepository), recordPrivateCalls = true)
 
-        viewModel.changeRole(PlayerRoles.RED_OPERATIVE, "Bob")
+    viewModel.changeRole(PlayerRoles.RED_OPERATIVE, "Bob", UUID.randomUUID())
 
         verify {
-            viewModel.changeRole(Role.OPERATIVE, Team.RED, "Bob")
+            viewModel.changeRole(Role.OPERATIVE, Team.RED, "Bob", any())
         }
     }
 
     @Test
     fun `getRoleForUser returns BLUE_OPERATIVE`() =
         runTest {
-            val repository = mockk<LobbyRepository>()
-            val viewModel = LobbyViewModel(repository)
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             val players =
                 listOf(
@@ -582,6 +582,8 @@ class LobbyViewModelTest {
                 repository.joinLobby("Max", "ABCD")
             } returns response
 
+            coEvery { sessionRepository.clearUserId() } just Runs
+
             viewModel.joinLobby("Max", "ABCD")
 
             advanceUntilIdle()
@@ -594,8 +596,7 @@ class LobbyViewModelTest {
     @Test
     fun `getRoleForUser returns NONE when player does not exist`() =
         runTest {
-            val repository = mockk<LobbyRepository>()
-            val viewModel = LobbyViewModel(repository)
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             val result = viewModel.getRoleForUser("Unknown")
 
@@ -605,8 +606,7 @@ class LobbyViewModelTest {
     @Test
     fun `changeRole updates player role correctly`() =
         runTest {
-            val repository = mockk<LobbyRepository>()
-            val viewModel = LobbyViewModel(repository)
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             val initialPlayers =
                 listOf(
@@ -642,13 +642,17 @@ class LobbyViewModelTest {
                     false,
                 )
 
+        val userId = UUID.randomUUID()
+
             coEvery {
                 repository.joinLobby("Max", "ABCD")
             } returns joinResponse
+            coEvery { sessionRepository.clearUserId() } just Runs
 
             coEvery {
                 repository.changeRole(
                     "Max",
+                    userId,
                     "ABCD",
                     Role.SPYMASTER,
                     Team.RED,
@@ -662,6 +666,7 @@ class LobbyViewModelTest {
                 role = Role.SPYMASTER,
                 team = Team.RED,
                 username = "Max",
+                userId = userId
             )
 
             advanceUntilIdle()
@@ -673,6 +678,7 @@ class LobbyViewModelTest {
             coVerify(exactly = 1) {
                 repository.changeRole(
                     "Max",
+                    any(),
                     "ABCD",
                     Role.SPYMASTER,
                     Team.RED,
@@ -683,13 +689,13 @@ class LobbyViewModelTest {
     @Test
     fun `changeRole sets error when not in lobby`() =
         runTest {
-            val repository = mockk<LobbyRepository>()
-            val viewModel = LobbyViewModel(repository)
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             viewModel.changeRole(
                 role = Role.SPYMASTER,
                 team = Team.RED,
                 username = "Max",
+                userId = UUID.randomUUID()
             )
 
             advanceUntilIdle()
@@ -702,36 +708,32 @@ class LobbyViewModelTest {
 
     @Test
     fun changeRole_DelegatesCorrectly_redSpymaster() {
-        val repository = mockk<LobbyRepository>()
-        val viewModel = spyk<LobbyViewModel>(LobbyViewModel(repository))
+        val viewModel = spyk<LobbyViewModel>(LobbyViewModel(repository, sessionRepository))
 
-        viewModel.changeRole(PlayerRoles.RED_SPYMASTER, "Alice")
+        viewModel.changeRole(PlayerRoles.RED_SPYMASTER, "Alice", UUID.randomUUID())
 
         verify {
-            viewModel.changeRole(Role.SPYMASTER, Team.RED, "Alice")
+            viewModel.changeRole(Role.SPYMASTER, Team.RED, "Alice", any())
         }
     }
 
     @Test
     fun changeRole_DelegatesCorrectly_blueOperative() {
-        val repository = mockk<LobbyRepository>()
-        val viewModel = spyk<LobbyViewModel>(LobbyViewModel(repository))
+        val viewModel = spyk<LobbyViewModel>(LobbyViewModel(repository, sessionRepository))
 
-        viewModel.changeRole(PlayerRoles.BLUE_OPERATIVE, "Bob")
+        viewModel.changeRole(PlayerRoles.BLUE_OPERATIVE, "Bob", UUID.randomUUID())
 
         verify {
-            viewModel.changeRole(Role.OPERATIVE, Team.BLUE, "Bob")
+            viewModel.changeRole(Role.OPERATIVE, Team.BLUE, "Bob", any())
         }
     }
 
     @Test
     fun changeRole_invalidRole_setsError() =
         runTest {
-            val repository = mockk<LobbyRepository>()
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
-            val viewModel = LobbyViewModel(repository)
-
-            viewModel.changeRole(PlayerRoles.NONE, "User")
+        viewModel.changeRole(PlayerRoles.NONE, "User", UUID.randomUUID())
 
             advanceUntilIdle()
 
@@ -743,8 +745,7 @@ class LobbyViewModelTest {
 
     @Test
     fun getRoleForUser_userNotFound_returnsNone() {
-        val repository = mockk<LobbyRepository>()
-        val viewModel = LobbyViewModel(repository)
+        val viewModel = LobbyViewModel(repository, sessionRepository)
 
         val result = viewModel.getRoleForUser("Unknown")
 
@@ -754,11 +755,9 @@ class LobbyViewModelTest {
     @Test
     fun sendStartGame_blankUsername_doesNothing() =
         runTest {
-            val repository = mockk<LobbyRepository>(relaxed = true)
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
-            val viewModel = LobbyViewModel(repository)
-
-            viewModel.sendStartGame("")
+            viewModel.sendStartGame("", UUID.randomUUID())
 
             advanceUntilIdle()
 
@@ -770,8 +769,6 @@ class LobbyViewModelTest {
     @Test
     fun getRoleForUser_blueOperative_returnsCorrectRole() =
         runTest {
-            val repository = mockk<LobbyRepository>()
-
             val response =
                 LobbyResponse(
                     lobbyCode = "12345",
@@ -791,7 +788,9 @@ class LobbyViewModelTest {
                 repository.joinLobby("Alice", "12345")
             } returns response
 
-            val viewModel = LobbyViewModel(repository)
+            coEvery { sessionRepository.clearUserId() } just Runs
+
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             viewModel.joinLobby("Alice", "12345")
 
@@ -805,8 +804,6 @@ class LobbyViewModelTest {
     @Test
     fun getRoleForUser_redSpymaster_returnsCorrectRole() =
         runTest {
-            val repository = mockk<LobbyRepository>()
-
             val response =
                 LobbyResponse(
                     lobbyCode = "12345",
@@ -826,7 +823,9 @@ class LobbyViewModelTest {
                 repository.joinLobby("Bob", "12345")
             } returns response
 
-            val viewModel = LobbyViewModel(repository)
+            coEvery { sessionRepository.clearUserId() } just Runs
+
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             viewModel.joinLobby("Bob", "12345")
 
@@ -840,8 +839,6 @@ class LobbyViewModelTest {
     @Test
     fun getRoleForUser_nullRole_returnsNone() =
         runTest {
-            val repository = mockk<LobbyRepository>()
-
             val response =
                 LobbyResponse(
                     lobbyCode = "12345",
@@ -861,7 +858,11 @@ class LobbyViewModelTest {
                 repository.joinLobby("Bob", "12345")
             } returns response
 
-            val viewModel = LobbyViewModel(repository)
+            coEvery {
+                sessionRepository.clearUserId()
+            } just Runs
+
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             viewModel.joinLobby("Bob", "12345")
 
@@ -875,8 +876,6 @@ class LobbyViewModelTest {
     @Test
     fun getIsHost_returnsTrueForHost() =
         runTest {
-            val repository = mockk<LobbyRepository>()
-
             val response =
                 LobbyResponse(
                     lobbyCode = "12345",
@@ -896,7 +895,9 @@ class LobbyViewModelTest {
                 repository.joinLobby("Host", "12345")
             } returns response
 
-            val viewModel = LobbyViewModel(repository)
+            coEvery { sessionRepository.clearUserId() } just Runs
+
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             viewModel.joinLobby("Host", "12345")
 
@@ -908,7 +909,6 @@ class LobbyViewModelTest {
     @Test
     fun getIsHost_returnsFalseForNonHost() =
         runTest {
-            val repository = mockk<LobbyRepository>()
 
             val response =
                 LobbyResponse(
@@ -927,7 +927,11 @@ class LobbyViewModelTest {
                 repository.joinLobby("User", "12345")
             } returns response
 
-            val viewModel = LobbyViewModel(repository)
+            coEvery {
+                sessionRepository.clearUserId()
+            } just Runs
+
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             viewModel.joinLobby("User", "12345")
 
@@ -941,8 +945,6 @@ class LobbyViewModelTest {
         runTest {
             mockkStatic(Log::class)
             every { Log.d(any(), any()) } returns 0
-
-            val repository = mockk<LobbyRepository>()
 
             val joinResponse =
                 LobbyResponse(
@@ -969,21 +971,23 @@ class LobbyViewModelTest {
             } returns joinResponse
 
             coEvery {
-                repository.sendStartGame("12345", "Host")
+                repository.sendStartGame("12345", any())
             } returns startResponse
 
-            val viewModel = LobbyViewModel(repository)
+            coEvery { sessionRepository.clearUserId() } just Runs
+
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             viewModel.joinLobby("Host", "12345")
 
             advanceUntilIdle()
 
-            viewModel.sendStartGame("Host")
+            viewModel.sendStartGame("Host", UUID.randomUUID())
 
             advanceUntilIdle()
 
             coVerify {
-                repository.sendStartGame("12345", "Host")
+                repository.sendStartGame("12345", any())
             }
         }
 
@@ -992,8 +996,6 @@ class LobbyViewModelTest {
         runTest {
             mockkStatic(Log::class)
             every { Log.d(any(), any()) } returns 0
-
-            val repository = mockk<LobbyRepository>()
 
             val joinResponse =
                 LobbyResponse(
@@ -1016,13 +1018,15 @@ class LobbyViewModelTest {
                 repository.sendStartGame(any(), any())
             } throws RuntimeException("Start failed")
 
-            val viewModel = LobbyViewModel(repository)
+            coEvery { sessionRepository.clearUserId() } just Runs
+
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             viewModel.joinLobby("Host", "12345")
 
             advanceUntilIdle()
 
-            viewModel.sendStartGame("Host")
+            viewModel.sendStartGame("Host", UUID.randomUUID())
 
             advanceUntilIdle()
 
@@ -1034,8 +1038,7 @@ class LobbyViewModelTest {
 
     @Test
     fun getAvailableChatTabsForUser_unknownUser_returnsGlobalOnly() {
-        val repository = mockk<LobbyRepository>()
-        val viewModel = LobbyViewModel(repository)
+        val viewModel = LobbyViewModel(repository, sessionRepository)
 
         val result = viewModel.getAvailableChatTabsForUser("Unknown")
 
@@ -1045,7 +1048,6 @@ class LobbyViewModelTest {
     @Test
     fun getAvailableChatTabsForUser_playerWithoutTeam_returnsGlobalOnly() =
         runTest {
-            val repository = mockk<LobbyRepository>()
             val response =
                 LobbyResponse(
                     lobbyCode = "12345",
@@ -1055,11 +1057,12 @@ class LobbyViewModelTest {
 
             coEvery { repository.joinLobby("Alice", "12345") } returns response
             coEvery { repository.getLobbyInfo("12345") } returns response
+            coEvery { sessionRepository.clearUserId() } just Runs
 
-            val viewModel = LobbyViewModel(repository)
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             viewModel.joinLobby("Alice", "12345")
-            advanceTimeBy(1)
+            advanceTimeBy(1.milliseconds)
             viewModel.stopPollingForTest()
 
             assertEquals(listOf(ChatTab.GLOBAL), viewModel.getAvailableChatTabsForUser("Alice"))
@@ -1068,7 +1071,6 @@ class LobbyViewModelTest {
     @Test
     fun getAvailableChatTabsForUser_spymasterWithTeam_returnsGlobalAndTeam() =
         runTest {
-            val repository = mockk<LobbyRepository>()
             val response =
                 LobbyResponse(
                     lobbyCode = "12345",
@@ -1078,11 +1080,12 @@ class LobbyViewModelTest {
 
             coEvery { repository.joinLobby("Alice", "12345") } returns response
             coEvery { repository.getLobbyInfo("12345") } returns response
+            coEvery { sessionRepository.clearUserId() } just Runs
 
-            val viewModel = LobbyViewModel(repository)
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             viewModel.joinLobby("Alice", "12345")
-            advanceTimeBy(1)
+            advanceTimeBy(1.milliseconds)
             viewModel.stopPollingForTest()
 
             assertEquals(listOf(ChatTab.GLOBAL, ChatTab.TEAM), viewModel.getAvailableChatTabsForUser("Alice"))
@@ -1091,7 +1094,6 @@ class LobbyViewModelTest {
     @Test
     fun getAvailableChatTabsForUser_singleOperative_returnsGlobalAndTeam() =
         runTest {
-            val repository = mockk<LobbyRepository>()
             val response =
                 LobbyResponse(
                     lobbyCode = "12345",
@@ -1105,11 +1107,12 @@ class LobbyViewModelTest {
 
             coEvery { repository.joinLobby("Alice", "12345") } returns response
             coEvery { repository.getLobbyInfo("12345") } returns response
+            coEvery { sessionRepository.clearUserId() } just Runs
 
-            val viewModel = LobbyViewModel(repository)
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             viewModel.joinLobby("Alice", "12345")
-            advanceTimeBy(1)
+            advanceTimeBy(1.milliseconds)
             viewModel.stopPollingForTest()
 
             assertEquals(
@@ -1121,7 +1124,6 @@ class LobbyViewModelTest {
     @Test
     fun getAvailableChatTabsForUser_multipleSameTeamOperatives_returnsAllTabs() =
         runTest {
-            val repository = mockk<LobbyRepository>()
             val response =
                 LobbyResponse(
                     lobbyCode = "12345",
@@ -1135,11 +1137,12 @@ class LobbyViewModelTest {
 
             coEvery { repository.joinLobby("Alice", "12345") } returns response
             coEvery { repository.getLobbyInfo("12345") } returns response
+            coEvery { sessionRepository.clearUserId() } just Runs
 
-            val viewModel = LobbyViewModel(repository)
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             viewModel.joinLobby("Alice", "12345")
-            advanceTimeBy(1)
+            advanceTimeBy(1.milliseconds)
             viewModel.stopPollingForTest()
 
             assertEquals(
@@ -1151,11 +1154,11 @@ class LobbyViewModelTest {
     @Test
     fun clearError_resetsError() =
         runTest {
-            val repository = mockk<LobbyRepository>()
 
             coEvery { repository.createLobby(any()) } throws RuntimeException("Network error")
+            coEvery { sessionRepository.clearUserId() } just Runs
 
-            val viewModel = LobbyViewModel(repository)
+            val viewModel = LobbyViewModel(repository, sessionRepository)
 
             viewModel.createLobby("Max")
 

--- a/app/src/test/java/com/codenames/frontend/viewmodel/LobbyViewModelTest.kt
+++ b/app/src/test/java/com/codenames/frontend/viewmodel/LobbyViewModelTest.kt
@@ -45,7 +45,6 @@ class LobbyViewModelTest {
     @Before
     fun setup() {
         Dispatchers.setMain(dispatcher)
-
     }
 
     @After
@@ -105,7 +104,6 @@ class LobbyViewModelTest {
     @Test
     fun testJoinLobby_success() =
         runTest {
-
             val response =
                 LobbyResponse(
                     lobbyCode = "1234",
@@ -141,7 +139,6 @@ class LobbyViewModelTest {
     @Test
     fun testJoinLobby_error() =
         runTest {
-
             coEvery { repository.joinLobby(any(), any()) } throws RuntimeException("Network error")
             coEvery { sessionRepository.clearUserId() } just Runs
 
@@ -162,7 +159,6 @@ class LobbyViewModelTest {
     @Test
     fun testLeaveLobby_success() =
         runTest {
-
             val response =
                 LobbyResponse(
                     lobbyCode = "1234",
@@ -188,7 +184,7 @@ class LobbyViewModelTest {
 
             viewModel.joinLobby("User", "1234")
             advanceTimeBy(2000.milliseconds)
-            viewModel.leaveLobby(userId = userId , onResult = {})
+            viewModel.leaveLobby(userId = userId, onResult = {})
 
             advanceTimeBy(2000.milliseconds)
 
@@ -204,7 +200,6 @@ class LobbyViewModelTest {
     @Test
     fun testLeaveLobby_error() =
         runTest {
-
             val response =
                 LobbyResponse(
                     lobbyCode = "1234",
@@ -238,7 +233,6 @@ class LobbyViewModelTest {
     @Test
     fun testChangeRole_success() =
         runTest {
-
             val newRole = Role.OPERATIVE
             val newTeam = Team.RED
             val username = "User"
@@ -286,7 +280,6 @@ class LobbyViewModelTest {
     @Test
     fun testChangeRole_error() =
         runTest {
-
             val response =
                 LobbyResponse(
                     lobbyCode = "1234",
@@ -301,7 +294,7 @@ class LobbyViewModelTest {
                     any(),
                     any(),
                     any(),
-                    any()
+                    any(),
                 )
             } throws RuntimeException("Network error")
 
@@ -328,7 +321,6 @@ class LobbyViewModelTest {
     @Test
     fun testSetError_WithEmptyValue() =
         runTest {
-
             coEvery { repository.createLobby(any()) } throws RuntimeException("")
             coEvery { sessionRepository.clearUserId() } just Runs
 
@@ -349,7 +341,6 @@ class LobbyViewModelTest {
     @Test
     fun testSetError_WithNullValue() =
         runTest {
-
             coEvery { repository.createLobby(any()) } throws RuntimeException()
             coEvery { sessionRepository.clearUserId() } just Runs
 
@@ -371,7 +362,6 @@ class LobbyViewModelTest {
     @Test
     fun testPolling_callsRepositoryRepeatedly() =
         runTest {
-
             coEvery { repository.getLobbyInfo(any()) } returns
                 LobbyResponse(
                     lobbyCode = "1234",
@@ -415,7 +405,6 @@ class LobbyViewModelTest {
     @Test
     fun testPolling_doesNotStartTwice() =
         runTest {
-
             coEvery { repository.getLobbyInfo("1234") } returns
                 LobbyResponse(
                     lobbyCode = "1234",
@@ -444,7 +433,6 @@ class LobbyViewModelTest {
     @Test
     fun testCreateLobby_alreadyInLobby() =
         runTest {
-
             val response =
                 LobbyResponse(
                     lobbyCode = "1234",
@@ -505,7 +493,6 @@ class LobbyViewModelTest {
     @Test
     fun testLeaveLobby_notInLobby() =
         runTest {
-
             val viewModel = LobbyViewModel(repository, sessionRepository)
 
             viewModel.leaveLobby(UUID.randomUUID(), onResult = {})
@@ -549,7 +536,7 @@ class LobbyViewModelTest {
     fun changeRole_DelegatesCorrectly2() {
         val viewModel = spyk<LobbyViewModel>(LobbyViewModel(repository, sessionRepository), recordPrivateCalls = true)
 
-    viewModel.changeRole(PlayerRoles.RED_OPERATIVE, "Bob", UUID.randomUUID())
+        viewModel.changeRole(PlayerRoles.RED_OPERATIVE, "Bob", UUID.randomUUID())
 
         verify {
             viewModel.changeRole(Role.OPERATIVE, Team.RED, "Bob", any())
@@ -642,7 +629,7 @@ class LobbyViewModelTest {
                     false,
                 )
 
-        val userId = UUID.randomUUID()
+            val userId = UUID.randomUUID()
 
             coEvery {
                 repository.joinLobby("Max", "ABCD")
@@ -666,7 +653,7 @@ class LobbyViewModelTest {
                 role = Role.SPYMASTER,
                 team = Team.RED,
                 username = "Max",
-                userId = userId
+                userId = userId,
             )
 
             advanceUntilIdle()
@@ -695,7 +682,7 @@ class LobbyViewModelTest {
                 role = Role.SPYMASTER,
                 team = Team.RED,
                 username = "Max",
-                userId = UUID.randomUUID()
+                userId = UUID.randomUUID(),
             )
 
             advanceUntilIdle()
@@ -733,7 +720,7 @@ class LobbyViewModelTest {
         runTest {
             val viewModel = LobbyViewModel(repository, sessionRepository)
 
-        viewModel.changeRole(PlayerRoles.NONE, "User", UUID.randomUUID())
+            viewModel.changeRole(PlayerRoles.NONE, "User", UUID.randomUUID())
 
             advanceUntilIdle()
 
@@ -909,7 +896,6 @@ class LobbyViewModelTest {
     @Test
     fun getIsHost_returnsFalseForNonHost() =
         runTest {
-
             val response =
                 LobbyResponse(
                     lobbyCode = "12345",
@@ -1154,7 +1140,6 @@ class LobbyViewModelTest {
     @Test
     fun clearError_resetsError() =
         runTest {
-
             coEvery { repository.createLobby(any()) } throws RuntimeException("Network error")
             coEvery { sessionRepository.clearUserId() } just Runs
 

--- a/app/src/test/java/com/codenames/frontend/viewmodel/LobbyViewModelTest.kt
+++ b/app/src/test/java/com/codenames/frontend/viewmodel/LobbyViewModelTest.kt
@@ -574,6 +574,16 @@ class LobbyViewModelTest {
     }
 
     @Test
+    fun changeRole_DoesNothingWithoutId() =
+        runTest {
+            val viewModel = LobbyViewModel(repository, sessionRepository)
+
+            viewModel.changeRole(PlayerRoles.RED_SPYMASTER, "User", null)
+
+            assertNotNull(viewModel.state.value.error)
+        }
+
+    @Test
     fun `getRoleForUser returns BLUE_OPERATIVE`() =
         runTest {
             val viewModel = LobbyViewModel(repository, sessionRepository)

--- a/app/src/test/java/com/codenames/frontend/viewmodel/LobbyViewModelTest.kt
+++ b/app/src/test/java/com/codenames/frontend/viewmodel/LobbyViewModelTest.kt
@@ -9,7 +9,6 @@ import com.codenames.frontend.data.repository.SessionRepository
 import com.codenames.frontend.network.dto.LobbyResponse
 import com.codenames.frontend.network.dto.PlayerDto
 import com.codenames.frontend.ui.roles.PlayerRoles
-import io.mockk.Awaits
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -509,16 +508,23 @@ class LobbyViewModelTest {
         }
 
     @Test
-    fun testLeaveLobby_nullIdSetsError() =
+    fun testLeaveLobby_nullIdDoesNothing() =
         runTest {
             val viewModel = LobbyViewModel(repository, sessionRepository)
             val username = "User"
             val lobbyCode = "ABCDE"
             val onResult = { bool: Boolean -> }
 
+            val response =
+                LobbyResponse(
+                    lobbyCode = "ABCDE",
+                    playerList = listOf(PlayerDto("User", null, Team.RED, true)),
+                    false,
+                )
+
             coEvery {
                 repository.joinLobby(username, lobbyCode)
-            } just Awaits
+            } returns response
             coEvery { sessionRepository.clearUserId() } just Runs
 
             viewModel.joinLobby(username, lobbyCode)
@@ -774,6 +780,18 @@ class LobbyViewModelTest {
 
             coVerify(exactly = 0) {
                 repository.sendStartGame(any(), any())
+            }
+        }
+
+    @Test
+    fun sendStartGame_NullId_doesNothing() =
+        runTest {
+            val viewModel = LobbyViewModel(repository, sessionRepository)
+
+            viewModel.sendStartGame("User", null)
+            advanceUntilIdle()
+            coVerify(exactly = 0) {
+                repository.sendStartGame("User", any())
             }
         }
 

--- a/app/src/test/java/com/codenames/frontend/viewmodel/LobbyViewModelTest.kt
+++ b/app/src/test/java/com/codenames/frontend/viewmodel/LobbyViewModelTest.kt
@@ -9,6 +9,7 @@ import com.codenames.frontend.data.repository.SessionRepository
 import com.codenames.frontend.network.dto.LobbyResponse
 import com.codenames.frontend.network.dto.PlayerDto
 import com.codenames.frontend.ui.roles.PlayerRoles
+import io.mockk.Awaits
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -34,6 +35,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.util.UUID
+import kotlin.test.assertNotNull
 import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -504,6 +506,28 @@ class LobbyViewModelTest {
             assertEquals(null, state.lobbyCode)
             assertFalse(state.isLoading)
             assertEquals("Not in a lobby, leaving not possible", state.error)
+        }
+
+    @Test
+    fun testLeaveLobby_nullIdSetsError() =
+        runTest {
+            val viewModel = LobbyViewModel(repository, sessionRepository)
+            val username = "User"
+            val lobbyCode = "ABCDE"
+            val onResult = { bool: Boolean -> }
+
+            coEvery {
+                repository.joinLobby(username, lobbyCode)
+            } just Awaits
+            coEvery { sessionRepository.clearUserId() } just Runs
+
+            viewModel.joinLobby(username, lobbyCode)
+
+            advanceUntilIdle()
+
+            viewModel.leaveLobby(null, onResult)
+
+            assertNotNull(viewModel.state.value.error)
         }
 
     @Test

--- a/app/src/test/java/com/codenames/frontend/viewmodel/SessionViewModelTest.kt
+++ b/app/src/test/java/com/codenames/frontend/viewmodel/SessionViewModelTest.kt
@@ -75,28 +75,18 @@ class SessionViewModelTest {
     }
 
     @Test
-    fun `setUserId updates user id`() {
-        val uuid = UUID.randomUUID()
-
-        viewModel.setUserId(uuid)
-
-        assertEquals(uuid, viewModel.userState.value.userId)
-    }
-
-    @Test
-    fun `persistUserState saves user`() =
+    fun `persistUserState saves username`() =
         runTest {
             val uuid = UUID.randomUUID()
 
             viewModel.setUsername("Max")
-            viewModel.setUserId(uuid)
 
             viewModel.persistUserState()
 
             advanceUntilIdle()
 
             coVerify {
-                sessionRepository.saveUser("Max", uuid)
+                sessionRepository.saveUser("Max", any())
             }
         }
 

--- a/app/src/test/java/com/codenames/frontend/viewmodel/SessionViewModelTest.kt
+++ b/app/src/test/java/com/codenames/frontend/viewmodel/SessionViewModelTest.kt
@@ -79,6 +79,8 @@ class SessionViewModelTest {
         runTest {
             val uuid = UUID.randomUUID()
 
+            viewModel.persistUserId(uuid)
+
             viewModel.setUsername("Max")
 
             viewModel.persistUserState()


### PR DESCRIPTION
# Context
This PR implements using the UUID for all requests that require it. This is the frontend addition to the backend PR and all design decisions were taken from there.

# Changes in the codebase
Changes to endpoints according to the backend endpoints
Changes to ID save flow to avoid loops 
ID is now newly generated every game to avoid duplicate database entries. This does not require backend changes.

# Additional information
There might be some bugs regarding cheat functions and chat, that were taken over from the last development step. However, we should fix those in a separate PR.

# Changes outside the codebase
N/A