### PR TITLE
Feature/90 cheat detection

### DIFF
--- a/app/src/main/java/com/codenames/frontend/data/model/ChatDomainModel.kt
+++ b/app/src/main/java/com/codenames/frontend/data/model/ChatDomainModel.kt
@@ -1,7 +1,10 @@
 package com.codenames.frontend.data.model
 
+import com.codenames.frontend.data.model.enums.CheatExposureResult
+
 data class ChatDomainModel(
     val sender: String,
     val text: String,
     val isFromMe: Boolean,
+    val cheatExposureResult: CheatExposureResult? = null,
 )

--- a/app/src/main/java/com/codenames/frontend/data/model/enums/CheatExposureResult.kt
+++ b/app/src/main/java/com/codenames/frontend/data/model/enums/CheatExposureResult.kt
@@ -1,0 +1,6 @@
+package com.codenames.frontend.data.model.enums
+
+enum class CheatExposureResult {
+    CORRECT,
+    WRONG,
+}

--- a/app/src/main/java/com/codenames/frontend/data/repository/ChatRepository.kt
+++ b/app/src/main/java/com/codenames/frontend/data/repository/ChatRepository.kt
@@ -1,6 +1,8 @@
 package com.codenames.frontend.data.repository
 
 import com.codenames.frontend.data.model.ChatDomainModel
+import com.codenames.frontend.data.model.enums.ChatMessageType
+import com.codenames.frontend.data.model.enums.CheatExposureResult
 import com.codenames.frontend.network.dto.ChatMessageDto
 import com.codenames.frontend.network.websocket.ChatWebSocketController
 import kotlinx.coroutines.flow.Flow
@@ -50,8 +52,9 @@ class ChatRepository
                     emit(
                         ChatDomainModel(
                             sender = dto.senderUsername,
-                            text = dto.content,
+                            text = dto.toDisplayText(),
                             isFromMe = dto.senderUsername == currentUsername,
+                            cheatExposureResult = dto.toCheatExposureResult(),
                         ),
                     )
                 }
@@ -117,10 +120,33 @@ class ChatRepository
                         emit(
                             ChatDomainModel(
                                 sender = dto.senderUsername,
-                                text = dto.content,
+                                text = dto.toDisplayText(),
                                 isFromMe = dto.senderUsername == currentUsername,
+                                cheatExposureResult = dto.toCheatExposureResult(),
                             ),
                         )
                     }
+            }
+
+        private fun ChatMessageDto.toCheatExposureResult(): CheatExposureResult? =
+            if (type == ChatMessageType.SYSTEM) {
+                when (content) {
+                    "EXPOSE_CORRECT" -> CheatExposureResult.CORRECT
+                    "EXPOSE_WRONG" -> CheatExposureResult.WRONG
+                    else -> null
+                }
+            } else {
+                null
+            }
+
+        private fun ChatMessageDto.toDisplayText(): String =
+            if (type == ChatMessageType.SYSTEM) {
+                when (content) {
+                    "EXPOSE_CORRECT" -> "Cheat exposed correctly. The opposing team's next turn is skipped."
+                    "EXPOSE_WRONG" -> "Wrong accusation. Your team's turn ends."
+                    else -> content
+                }
+            } else {
+                content
             }
     }

--- a/app/src/main/java/com/codenames/frontend/data/repository/GameRepository.kt
+++ b/app/src/main/java/com/codenames/frontend/data/repository/GameRepository.kt
@@ -3,6 +3,7 @@ package com.codenames.frontend.data.repository
 import com.codenames.frontend.data.model.enums.Team
 import com.codenames.frontend.network.dto.CheatCardMessage
 import com.codenames.frontend.network.dto.ClueMessageDto
+import com.codenames.frontend.network.dto.ExposeCheatMessage
 import com.codenames.frontend.network.dto.GuessMessage
 import com.codenames.frontend.network.dto.PassTurnMessage
 import com.codenames.frontend.network.dto.StartGameMessage
@@ -85,5 +86,13 @@ class GameRepository
                 )
 
             webSocketHandler.sendCheat(msg)
+        }
+
+        suspend fun exposeCheat(
+            lobbyCode: String,
+            username: String,
+        ) {
+            val msg = ExposeCheatMessage(lobbyCode, username)
+            webSocketHandler.exposeCheat(msg)
         }
     }

--- a/app/src/main/java/com/codenames/frontend/network/dto/ExposeCheatMessage.kt
+++ b/app/src/main/java/com/codenames/frontend/network/dto/ExposeCheatMessage.kt
@@ -1,0 +1,9 @@
+package com.codenames.frontend.network.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ExposeCheatMessage(
+    val lobbyCode: String,
+    val username: String,
+)

--- a/app/src/main/java/com/codenames/frontend/network/websocket/GameWebSocketController.kt
+++ b/app/src/main/java/com/codenames/frontend/network/websocket/GameWebSocketController.kt
@@ -2,6 +2,7 @@ package com.codenames.frontend.network.websocket
 
 import com.codenames.frontend.network.dto.CheatCardMessage
 import com.codenames.frontend.network.dto.ClueMessageDto
+import com.codenames.frontend.network.dto.ExposeCheatMessage
 import com.codenames.frontend.network.dto.GameMessage
 import com.codenames.frontend.network.dto.GuessMessage
 import com.codenames.frontend.network.dto.PassTurnMessage
@@ -56,6 +57,14 @@ class GameWebSocketController
                 "/app/cheat",
                 msg,
                 CheatCardMessage.serializer(),
+            )
+        }
+
+        suspend fun exposeCheat(msg: ExposeCheatMessage) {
+            webSocketSessionManager.getSession().convertAndSend(
+                "/app/expose-cheat",
+                msg,
+                ExposeCheatMessage.serializer(),
             )
         }
     }

--- a/app/src/main/java/com/codenames/frontend/ui/screens/GameScreenWrapper.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/GameScreenWrapper.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.navigation.NavHostController
+import com.codenames.frontend.data.model.enums.CheatExposureResult
 import com.codenames.frontend.ui.navigation.Screen
 import com.codenames.frontend.viewmodel.ChatViewModel
 import com.codenames.frontend.viewmodel.GameViewModel
@@ -32,6 +33,10 @@ fun GameScreenWrapper(
     val userRole = lobbyViewModel.getRoleForUser(username)
     val availableChatTabs = lobbyViewModel.getAvailableChatTabsForUser(username)
     val winner = gameState.winner
+    val cheatSuccessfullyExposed =
+        chatState.operativeMessages.any {
+            it.cheatExposureResult == CheatExposureResult.CORRECT
+        }
 
     LaunchedEffect(winner) {
         if (winner != null) {
@@ -41,6 +46,7 @@ fun GameScreenWrapper(
 
     GameboardScreen(
         userRole = userRole,
+        isExposeCheatAvailable = !cheatSuccessfullyExposed,
         gameState =
             gameState.copy(
                 chatLists = chatState,
@@ -60,6 +66,12 @@ fun GameScreenWrapper(
                 lobbyCode = lobbyCode,
                 username = username,
                 positions = positions,
+            )
+        },
+        onExposeCheat = {
+            gameViewModel.exposeCheat(
+                lobbyCode = lobbyCode,
+                username = username,
             )
         },
         onSendChatMessage = { tab, message ->

--- a/app/src/main/java/com/codenames/frontend/ui/screens/GameboardScreen.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/GameboardScreen.kt
@@ -112,24 +112,28 @@ private data class ChatOverlayState(
     val messages: ChatLists,
     val selectedTab: ChatTab,
     val availableTabs: List<ChatTab>,
+    val canExposeCheat: Boolean,
 )
 
 private data class ChatOverlayActions(
     val onTabSelected: (ChatTab) -> Unit,
     val onInputChange: (String) -> Unit,
     val onSendMessage: (ChatTab, String) -> Unit,
+    val onExposeCheat: () -> Unit,
 )
 
 @Suppress("ktlint:standard:function-naming")
 @Composable
 fun GameboardScreen(
     userRole: PlayerRoles,
+    isExposeCheatAvailable: Boolean = true,
     gameState: GameState,
     onHintChange: (String, Int) -> Unit,
     onReveal: (List<Int>) -> Unit,
     onCheatRequest: (List<Int>) -> Unit,
     modifier: Modifier = Modifier,
     onPassTurn: () -> Unit = {},
+    onExposeCheat: () -> Unit = {},
     onSendChatMessage: (ChatTab, String) -> Unit = { _, _ -> },
     onSettingsClick: (() -> Unit)? = null,
     onReturnToHome: (() -> Unit),
@@ -157,7 +161,8 @@ fun GameboardScreen(
     val isSpymaster =
         userRole == PlayerRoles.BLUE_SPYMASTER || userRole == PlayerRoles.RED_SPYMASTER
     val isActiveSpymaster = userRole == currentTurn && isSpymaster
-    val canEndTurn = userRole == currentTurn && !isSpymaster && remainingGuesses > 0
+    val isActiveOperative = userRole == currentTurn && !isSpymaster
+    val canEndTurn = isActiveOperative && remainingGuesses > 0
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusManager = LocalFocusManager.current
 
@@ -304,12 +309,14 @@ fun GameboardScreen(
                     messages = chatLists,
                     selectedTab = selectedChatTab,
                     availableTabs = availableChatTabs,
+                    canExposeCheat = isActiveOperative && isExposeCheatAvailable,
                 ),
             actions =
                 ChatOverlayActions(
                     onTabSelected = { selectedChatTab = it },
                     onInputChange = { chatInput = it },
                     onSendMessage = onSendChatMessage,
+                    onExposeCheat = onExposeCheat,
                 ),
             modifier =
                 Modifier
@@ -568,6 +575,8 @@ private fun GameChatOverlay(
             onTabSelected = actions.onTabSelected,
             onChatInputChange = actions.onInputChange,
             onSendClick = actions.onSendMessage,
+            canExposeCheat = state.canExposeCheat,
+            onExposeCheat = actions.onExposeCheat,
             modifier = modifier,
         )
     }
@@ -655,6 +664,8 @@ fun ChatWindow(
     onTabSelected: (ChatTab) -> Unit,
     onChatInputChange: (String) -> Unit,
     onSendClick: (ChatTab, String) -> Unit,
+    canExposeCheat: Boolean = false,
+    onExposeCheat: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val dimensions = LocalResponsiveDimensions.current
@@ -706,6 +717,25 @@ fun ChatWindow(
         )
 
         Spacer(modifier = Modifier.height(dimensions.itemSpacing))
+
+        if (selectedTab == ChatTab.OPERATIVES && canExposeCheat) {
+            AppButton(
+                text = "Expose Cheat",
+                onClick = onExposeCheat,
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(dimensions.secondaryButtonHeight),
+                style =
+                    AppButtonStyle(
+                        containerColor = AppRed,
+                        contentColor = AppWhite,
+                        fontSize = dimensions.smallFontSize,
+                    ),
+            )
+
+            Spacer(modifier = Modifier.height(dimensions.itemSpacing))
+        }
 
         Row(
             modifier =

--- a/app/src/main/java/com/codenames/frontend/viewmodel/GameViewModel.kt
+++ b/app/src/main/java/com/codenames/frontend/viewmodel/GameViewModel.kt
@@ -172,6 +172,23 @@ class GameViewModel
             }
         }
 
+        fun exposeCheat(
+            lobbyCode: String,
+            username: String,
+        ) {
+            if (lobbyCode.isBlank() || username.isBlank()) {
+                return
+            }
+
+            viewModelScope.launch {
+                try {
+                    gameRepository.exposeCheat(lobbyCode, username)
+                } catch (e: Exception) {
+                    setConnectionError(e)
+                }
+            }
+        }
+
         fun passTurn(
             lobbyCode: String,
             team: Team?,

--- a/app/src/test/java/com/codenames/frontend/data/repository/ChatRepositoryTest.kt
+++ b/app/src/test/java/com/codenames/frontend/data/repository/ChatRepositoryTest.kt
@@ -1,5 +1,7 @@
 package com.codenames.frontend.data.repository
 
+import com.codenames.frontend.data.model.enums.ChatMessageType
+import com.codenames.frontend.data.model.enums.CheatExposureResult
 import com.codenames.frontend.network.dto.ChatMessageDto
 import com.codenames.frontend.network.websocket.ChatWebSocketController
 import io.mockk.Runs
@@ -336,5 +338,32 @@ class ChatRepositoryTest {
 
             assertEquals("System", result[0].sender)
             assertEquals("London is correct", result[0].text)
+        }
+
+    @Test
+    fun testObserveOperativeChat_mapsCorrectExposeResult() =
+        runTest {
+            val dto = ChatMessageDto("System", "EXPOSE_CORRECT", ChatMessageType.SYSTEM)
+            coEvery { chatSocketHandler.subscribeToChat(operativeTopic) } returns flowOf(dto)
+
+            val result = repository.observeOperativeChat(testLobbyCode, testTeam, testUser).toList()
+
+            assertEquals(
+                "Cheat exposed correctly. The opposing team's next turn is skipped.",
+                result[0].text,
+            )
+            assertEquals(CheatExposureResult.CORRECT, result[0].cheatExposureResult)
+        }
+
+    @Test
+    fun testObserveOperativeChat_mapsWrongExposeResult() =
+        runTest {
+            val dto = ChatMessageDto("System", "EXPOSE_WRONG", ChatMessageType.SYSTEM)
+            coEvery { chatSocketHandler.subscribeToChat(operativeTopic) } returns flowOf(dto)
+
+            val result = repository.observeOperativeChat(testLobbyCode, testTeam, testUser).toList()
+
+            assertEquals("Wrong accusation. Your team's turn ends.", result[0].text)
+            assertEquals(CheatExposureResult.WRONG, result[0].cheatExposureResult)
         }
 }

--- a/app/src/test/java/com/codenames/frontend/data/repository/GameRepositoryTest.kt
+++ b/app/src/test/java/com/codenames/frontend/data/repository/GameRepositoryTest.kt
@@ -86,6 +86,16 @@ class GameRepositoryTest {
         }
 
     @Test
+    fun testExposeCheat() =
+        runTest {
+            coEvery { webSocketHandler.exposeCheat(any()) } just Runs
+
+            gameRepository.exposeCheat("ABCDE", "Max")
+
+            coVerify { webSocketHandler.exposeCheat(any()) }
+        }
+
+    @Test
     fun testPassTurn() =
         runTest {
             val lobbyCode = "ABCDE"

--- a/app/src/test/java/com/codenames/frontend/network/websocket/GameWebSocketControllerTest.kt
+++ b/app/src/test/java/com/codenames/frontend/network/websocket/GameWebSocketControllerTest.kt
@@ -3,6 +3,7 @@ package com.codenames.frontend.network.websocket
 import com.codenames.frontend.data.model.enums.Team
 import com.codenames.frontend.network.dto.CheatCardMessage
 import com.codenames.frontend.network.dto.ClueMessageDto
+import com.codenames.frontend.network.dto.ExposeCheatMessage
 import com.codenames.frontend.network.dto.GameMessage
 import com.codenames.frontend.network.dto.GuessMessage
 import com.codenames.frontend.network.dto.PassTurnMessage
@@ -146,6 +147,22 @@ class GameWebSocketControllerTest {
                     "/app/cheat",
                     cheatMessage,
                     CheatCardMessage.serializer(),
+                )
+            }
+        }
+
+    @Test
+    fun testExposeCheat() =
+        runTest {
+            val message = ExposeCheatMessage("LOBBY123", "Max")
+
+            wsClient.exposeCheat(message)
+
+            coVerify {
+                session.convertAndSend(
+                    "/app/expose-cheat",
+                    message,
+                    ExposeCheatMessage.serializer(),
                 )
             }
         }

--- a/app/src/test/java/com/codenames/frontend/viewmodel/GameViewModelTest.kt
+++ b/app/src/test/java/com/codenames/frontend/viewmodel/GameViewModelTest.kt
@@ -751,4 +751,34 @@ class GameViewModelTest {
 
             assertTrue(viewModel.connectionState.value is ConnectionState.Error)
         }
+
+    @Test
+    fun exposeCheat_callsRepository() =
+        runTest {
+            viewModel.exposeCheat("ABCD", "Max")
+
+            advanceUntilIdle()
+
+            coVerify { gameRepository.exposeCheat("ABCD", "Max") }
+        }
+
+    @Test
+    fun exposeCheat_invalidInput_doesNothing() =
+        runTest {
+            viewModel.exposeCheat("", "Max")
+            viewModel.exposeCheat("ABCD", "")
+
+            coVerify(exactly = 0) { gameRepository.exposeCheat(any(), any()) }
+        }
+
+    @Test
+    fun exposeCheat_repositoryThrows() =
+        runTest {
+            coEvery { gameRepository.exposeCheat(any(), any()) } throws RuntimeException()
+
+            viewModel.exposeCheat("ABCD", "Max")
+            advanceUntilIdle()
+
+            assertTrue(viewModel.connectionState.value is ConnectionState.Error)
+        }
 }


### PR DESCRIPTION
## Context
Adds frontend support for cheat detection and cheat exposure during operative gameplay.

## Description
Implemented the frontend WebSocket flow and UI action for exposing cheats. Operatives can trigger cheat detection through the existing shake flow, and expose-cheat results are shown in the operative chat.

## Changes in the codebase
Added expose-cheat WebSocket message DTO
Added expose-cheat send flow in GameWebSocketController
Added expose-cheat repository and ViewModel actions
Added “Expose Cheat” button to operative chat
Added mapping for expose-cheat system messages
Added frontend state for correct/wrong expose results
Hide expose-cheat button after a correct exposure
Added/updated tests for GameWebSocketController, GameRepository, GameViewModel, and ChatRepository

## Changes outside the codebase
N/A

## Additional information
The expose-cheat button is only shown in the operative chat during the player’s active operative phase. Correct exposure hides the button and shows a success message; wrong exposure shows a penalty message.