### PR TITLE
Fix/rejoin chat subscription

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -55,6 +55,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-354257922">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_7" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="27987255">
           <value>
             <AndroidTestResultsTableState>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="ms-21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/com/codenames/frontend/ui/buttons/AppSendButton.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/buttons/AppSendButton.kt
@@ -1,0 +1,48 @@
+package com.codenames.frontend.ui.buttons
+
+import androidx.compose.foundation.background
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import com.codenames.frontend.ui.theme.greenGradient
+
+@Composable
+fun AppSendButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    style: AppButtonStyle = AppButtonStyle()
+) {
+    val resolvedContainerColor =
+        when {
+            style.containerColor != Color.Unspecified -> style.containerColor
+            else -> MaterialTheme.colorScheme.primary
+        }
+
+    val resolvedContentColor =
+        when {
+            style.contentColor != Color.Unspecified -> style.contentColor
+            style.type == AppButtonType.SECONDARY -> MaterialTheme.colorScheme.primary
+            else -> MaterialTheme.colorScheme.onPrimary
+        }
+
+    IconButton(
+        onClick = onClick,
+        enabled = style.enabled,
+        modifier = modifier.background(style.backgroundBrush ?: greenGradient, shape = style.shape),
+        colors = IconButtonDefaults.iconButtonColors(
+            containerColor =  Color.Transparent,
+            contentColor = resolvedContentColor
+        )
+    ) {
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.Send,
+            contentDescription = "Send",
+        )
+    }
+}

--- a/app/src/main/java/com/codenames/frontend/ui/buttons/AppSendButton.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/buttons/AppSendButton.kt
@@ -12,11 +12,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import com.codenames.frontend.ui.theme.greenGradient
 
+@Suppress("ktlint:standard:function-naming")
 @Composable
 fun AppSendButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    style: AppButtonStyle = AppButtonStyle()
+    style: AppButtonStyle = AppButtonStyle(),
 ) {
     val resolvedContainerColor =
         when {
@@ -35,10 +36,11 @@ fun AppSendButton(
         onClick = onClick,
         enabled = style.enabled,
         modifier = modifier.background(style.backgroundBrush ?: greenGradient, shape = style.shape),
-        colors = IconButtonDefaults.iconButtonColors(
-            containerColor =  Color.Transparent,
-            contentColor = resolvedContentColor
-        )
+        colors =
+            IconButtonDefaults.iconButtonColors(
+                containerColor = Color.Transparent,
+                contentColor = resolvedContentColor,
+            ),
     ) {
         Icon(
             imageVector = Icons.AutoMirrored.Filled.Send,

--- a/app/src/main/java/com/codenames/frontend/ui/buttons/AppSendButton.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/buttons/AppSendButton.kt
@@ -19,12 +19,6 @@ fun AppSendButton(
     modifier: Modifier = Modifier,
     style: AppButtonStyle = AppButtonStyle(),
 ) {
-    val resolvedContainerColor =
-        when {
-            style.containerColor != Color.Unspecified -> style.containerColor
-            else -> MaterialTheme.colorScheme.primary
-        }
-
     val resolvedContentColor =
         when {
             style.contentColor != Color.Unspecified -> style.contentColor

--- a/app/src/main/java/com/codenames/frontend/ui/buttons/SettingsCornerButton.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/buttons/SettingsCornerButton.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -33,7 +34,7 @@ fun BoxScope.SettingsCornerButton(onClick: () -> Unit) {
                 .height(dimensions.cornerButtonSize)
                 .zIndex(1f),
     ) {
-        androidx.compose.material3.IconButton(
+        IconButton(
             onClick = onClick,
             modifier = Modifier.fillMaxSize(),
             colors =

--- a/app/src/main/java/com/codenames/frontend/ui/composables/GameBoardGrid.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/composables/GameBoardGrid.kt
@@ -1,20 +1,34 @@
 package com.codenames.frontend.ui.composables
 
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
 import com.codenames.frontend.data.model.GameCard
-import com.codenames.frontend.ui.screens.CodenamesCard
+import com.codenames.frontend.data.model.enums.CardType
+import com.codenames.frontend.ui.buttons.AppButton
+import com.codenames.frontend.ui.buttons.AppButtonStyle
+import com.codenames.frontend.ui.screens.getColor
+import com.codenames.frontend.ui.theme.AppGreen
+import com.codenames.frontend.ui.theme.AppInk
+import com.codenames.frontend.ui.theme.AppLightGray
+import com.codenames.frontend.ui.theme.AppSurface
+import com.codenames.frontend.ui.theme.AppWhite
+import com.codenames.frontend.ui.theme.LocalResponsiveDimensions
 
 const val BOARD_COLUMNS = 5
+const val LINEBREAK_TRESHOLD = 8
 
 @Suppress("ktlint:standard:function-naming")
 @Composable
@@ -75,4 +89,59 @@ fun GameBoardGrid(
                 }
         }
     }
+}
+
+@Suppress("ktlint:standard:function-naming")
+@Composable
+fun CodenamesCard(
+    card: GameCard,
+    isSpymaster: Boolean,
+    isSelected: Boolean = false,
+    onClick: () -> Unit,
+) {
+    val dimensions = LocalResponsiveDimensions.current
+    val cardShape = RoundedCornerShape(12.dp)
+
+    val backgroundColor =
+        when {
+            card.revealed && card.type == CardType.NEUTRAL -> AppLightGray
+            card.revealed -> getColor(card.type)
+            isSpymaster -> getColor(card.type)
+            else -> AppSurface
+        }
+
+    val contentColor =
+        if (backgroundColor == AppSurface) {
+            AppInk
+        } else {
+            AppWhite
+        }
+
+    AppButton(
+        text = card.word,
+        onClick = onClick,
+        modifier =
+            Modifier
+                .aspectRatio(2f)
+                .then(
+                    if (isSelected) {
+                        Modifier.border(3.dp, AppGreen, cardShape)
+                    } else {
+                        Modifier
+                    },
+                ).then(
+                    if (card.revealed) {
+                        Modifier.alpha(0.75f)
+                    } else {
+                        Modifier
+                    },
+                ),
+        style =
+            AppButtonStyle(
+                containerColor = backgroundColor,
+                contentColor = contentColor,
+            fontSize = if(card.word.length < LINEBREAK_TRESHOLD ) dimensions.cardFontSize else dimensions.smallCardFontSize,
+                shape = cardShape,
+            ),
+    )
 }

--- a/app/src/main/java/com/codenames/frontend/ui/composables/GameBoardGrid.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/composables/GameBoardGrid.kt
@@ -140,7 +140,7 @@ fun CodenamesCard(
             AppButtonStyle(
                 containerColor = backgroundColor,
                 contentColor = contentColor,
-            fontSize = if(card.word.length < LINEBREAK_TRESHOLD ) dimensions.cardFontSize else dimensions.smallCardFontSize,
+                fontSize = if (card.word.length < LINEBREAK_TRESHOLD) dimensions.cardFontSize else dimensions.smallCardFontSize,
                 shape = cardShape,
             ),
     )

--- a/app/src/main/java/com/codenames/frontend/ui/inputs/AppTextField.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/inputs/AppTextField.kt
@@ -152,6 +152,10 @@ private fun PrimaryAppTextField(
                 focusedPlaceholderColor = contentColor.copy(alpha = 0.6f),
                 unfocusedPlaceholderColor = contentColor.copy(alpha = 0.6f),
                 cursorColor = contentColor,
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent,
+                disabledIndicatorColor = Color.Transparent,
+                errorIndicatorColor = Color.Transparent,
             ),
     )
 }

--- a/app/src/main/java/com/codenames/frontend/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/navigation/NavGraph.kt
@@ -11,6 +11,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.codenames.frontend.data.model.enums.ConnectionState
 import com.codenames.frontend.ui.composables.ErrorDialog
+import com.codenames.frontend.ui.screens.ForceLandscape
 import com.codenames.frontend.ui.screens.GameScreenWrapper
 import com.codenames.frontend.ui.screens.GameSettingsScreen
 import com.codenames.frontend.ui.screens.JoinlobbyScreen
@@ -53,6 +54,7 @@ fun NavGraph(
                 maxWidth = maxWidth,
                 maxHeight = maxHeight,
             )
+        ForceLandscape()
 
         CompositionLocalProvider(LocalResponsiveDimensions provides responsiveDimensions) {
             NavHost(

--- a/app/src/main/java/com/codenames/frontend/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/navigation/NavGraph.kt
@@ -58,7 +58,7 @@ fun NavGraph(
                 startDestination = Screen.Username.route,
             ) {
                 composable(Screen.Username.route) {
-                    UserNameScreen(navController, sessionViewModel, gameViewModel, lobbyViewModel)
+                    UserNameScreen(navController, sessionViewModel, gameViewModel, lobbyViewModel, chatViewModel)
                 }
 
                 composable(Screen.Start.route) {

--- a/app/src/main/java/com/codenames/frontend/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/navigation/NavGraph.kt
@@ -38,11 +38,13 @@ fun NavGraph(
     val lobbyState by lobbyViewModel.state.collectAsState()
     val connectionState by gameViewModel.connectionState.collectAsState()
     val chatErrorMessage by chatViewModel.errorMessage.collectAsState()
+    val gameErrorMessage by gameViewModel.errorMessage.collectAsState()
 
     val errorMessage: String? =
         lobbyState.error
             ?: (connectionState as? ConnectionState.Error)?.message
             ?: chatErrorMessage
+            ?: gameErrorMessage
 
     @Suppress("UnusedBoxWithConstraintsScope")
     BoxWithConstraints {
@@ -112,6 +114,7 @@ fun NavGraph(
                     onDismiss = {
                         lobbyViewModel.clearError()
                         gameViewModel.clearError()
+                        gameViewModel.clearErrorState()
                         chatViewModel.clearError()
                     },
                 )

--- a/app/src/main/java/com/codenames/frontend/ui/screens/GameboardScreen.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/GameboardScreen.kt
@@ -5,7 +5,6 @@ import android.hardware.Sensor
 import android.hardware.SensorManager
 import android.util.Log
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -13,7 +12,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -38,7 +36,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.geometry.Offset
@@ -670,7 +667,6 @@ fun ChatWindow(
     modifier: Modifier = Modifier,
     canExposeCheat: Boolean = false,
     onExposeCheat: () -> Unit = {},
-
 ) {
     val dimensions = LocalResponsiveDimensions.current
 
@@ -957,7 +953,7 @@ fun HintSection(
         Row(
             horizontalArrangement = Arrangement.spacedBy(dimensions.itemSpacing),
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(horizontal = dimensions.largeSpacing)
+            modifier = Modifier.padding(horizontal = dimensions.largeSpacing),
         ) {
             AppTextField(
                 value = hintInput,
@@ -1007,11 +1003,13 @@ fun HintSection(
                         fontSize = dimensions.bodyFontSize,
                         lineHeight = dimensions.buttonLineHeight,
                     ),
-                keyboard = AppTextFieldKeyboard(
-                    options = KeyboardOptions(
-                        keyboardType = KeyboardType.Number
-                    )
-                ),
+                keyboard =
+                    AppTextFieldKeyboard(
+                        options =
+                            KeyboardOptions(
+                                keyboardType = KeyboardType.Number,
+                            ),
+                    ),
             )
 
             AppSendButton(
@@ -1025,13 +1023,15 @@ fun HintSection(
                         keyboardController?.hide()
                     }
                 },
-                modifier =  Modifier
-                    .width(dimensions.gameHintSendButtonWidth)
-                    .height(dimensions.gameHintInputHeight),
-                style =  AppButtonStyle(
-                    fontSize = dimensions.bodyFontSize,
-                    lineHeight = dimensions.buttonLineHeight,
-                )
+                modifier =
+                    Modifier
+                        .width(dimensions.gameHintSendButtonWidth)
+                        .height(dimensions.gameHintInputHeight),
+                style =
+                    AppButtonStyle(
+                        fontSize = dimensions.bodyFontSize,
+                        lineHeight = dimensions.buttonLineHeight,
+                    ),
             )
         }
     } else {

--- a/app/src/main/java/com/codenames/frontend/ui/screens/GameboardScreen.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/GameboardScreen.kt
@@ -289,7 +289,7 @@ fun GameboardScreen(
                         .weight(1f)
                         .fillMaxWidth(),
             )
-            if (!gameOver && isSpymaster) {
+            if (!gameOver) {
                 HintSection(
                     isActiveSpymaster,
                     currentHint,

--- a/app/src/main/java/com/codenames/frontend/ui/screens/GameboardScreen.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/GameboardScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -49,6 +50,7 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.codenames.frontend.data.model.ChatDomainModel
 import com.codenames.frontend.data.model.ChatLists
@@ -60,6 +62,7 @@ import com.codenames.frontend.data.model.enums.Team
 import com.codenames.frontend.ui.buttons.AppButton
 import com.codenames.frontend.ui.buttons.AppButtonStyle
 import com.codenames.frontend.ui.buttons.AppButtonType
+import com.codenames.frontend.ui.buttons.AppSendButton
 import com.codenames.frontend.ui.buttons.SettingsCornerButton
 import com.codenames.frontend.ui.composables.GameBoardGrid
 import com.codenames.frontend.ui.inputs.AppTextField
@@ -286,7 +289,7 @@ fun GameboardScreen(
                         .weight(1f)
                         .fillMaxWidth(),
             )
-            if (!gameOver) {
+            if (!gameOver && isSpymaster) {
                 HintSection(
                     isActiveSpymaster,
                     currentHint,
@@ -664,9 +667,10 @@ fun ChatWindow(
     onTabSelected: (ChatTab) -> Unit,
     onChatInputChange: (String) -> Unit,
     onSendClick: (ChatTab, String) -> Unit,
+    modifier: Modifier = Modifier,
     canExposeCheat: Boolean = false,
     onExposeCheat: () -> Unit = {},
-    modifier: Modifier = Modifier,
+
 ) {
     val dimensions = LocalResponsiveDimensions.current
 
@@ -761,13 +765,12 @@ fun ChatWindow(
                     AppTextFieldStyle(
                         containerColor = AppSurface,
                         contentColor = AppInk,
-                        fontSize = dimensions.smallFontSize,
+                        fontSize = dimensions.bodyFontSize,
                         lineHeight = dimensions.bodyFontSize,
                     ),
             )
 
-            AppButton(
-                text = "Send",
+            AppSendButton(
                 onClick = {
                     val trimmedMessage = chatInput.trim()
                     if (trimmedMessage.isNotBlank()) {
@@ -777,7 +780,7 @@ fun ChatWindow(
                 },
                 modifier =
                     Modifier
-                        .width(dimensions.returnButtonWidth)
+                        .width(dimensions.cornerButtonSize)
                         .fillMaxHeight(),
                 style =
                     AppButtonStyle(
@@ -952,8 +955,9 @@ fun HintSection(
 
     if (isSpymaster) {
         Row(
-            horizontalArrangement = Arrangement.spacedBy(dimensions.smallSpacing),
+            horizontalArrangement = Arrangement.spacedBy(dimensions.itemSpacing),
             verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(horizontal = dimensions.largeSpacing)
         ) {
             AppTextField(
                 value = hintInput,
@@ -1003,10 +1007,14 @@ fun HintSection(
                         fontSize = dimensions.bodyFontSize,
                         lineHeight = dimensions.buttonLineHeight,
                     ),
+                keyboard = AppTextFieldKeyboard(
+                    options = KeyboardOptions(
+                        keyboardType = KeyboardType.Number
+                    )
+                ),
             )
 
-            AppButton(
-                text = "SEND",
+            AppSendButton(
                 onClick = {
                     val count = countInput.toIntOrNull() ?: 0
                     if (hintInput.isNotBlank()) {
@@ -1017,15 +1025,13 @@ fun HintSection(
                         keyboardController?.hide()
                     }
                 },
-                modifier =
-                    Modifier
-                        .width(dimensions.gameHintSendButtonWidth)
-                        .height(dimensions.gameHintInputHeight),
-                style =
-                    AppButtonStyle(
-                        fontSize = dimensions.bodyFontSize,
-                        lineHeight = dimensions.buttonLineHeight,
-                    ),
+                modifier =  Modifier
+                    .width(dimensions.gameHintSendButtonWidth)
+                    .height(dimensions.gameHintInputHeight),
+                style =  AppButtonStyle(
+                    fontSize = dimensions.bodyFontSize,
+                    lineHeight = dimensions.buttonLineHeight,
+                )
             )
         }
     } else {
@@ -1075,61 +1081,6 @@ fun TeamRoleBox(
             )
         }
     }
-}
-
-@Suppress("ktlint:standard:function-naming")
-@Composable
-fun CodenamesCard(
-    card: GameCard,
-    isSpymaster: Boolean,
-    isSelected: Boolean = false,
-    onClick: () -> Unit,
-) {
-    val dimensions = LocalResponsiveDimensions.current
-    val cardShape = RoundedCornerShape(12.dp)
-
-    val backgroundColor =
-        when {
-            card.revealed && card.type == CardType.NEUTRAL -> AppLightGray
-            card.revealed -> getColor(card.type)
-            isSpymaster -> getColor(card.type)
-            else -> AppSurface
-        }
-
-    val contentColor =
-        if (backgroundColor == AppSurface) {
-            AppInk
-        } else {
-            AppWhite
-        }
-
-    AppButton(
-        text = card.word,
-        onClick = onClick,
-        modifier =
-            Modifier
-                .aspectRatio(2f)
-                .then(
-                    if (isSelected) {
-                        Modifier.border(3.dp, AppGreen, cardShape)
-                    } else {
-                        Modifier
-                    },
-                ).then(
-                    if (card.revealed) {
-                        Modifier.alpha(0.75f)
-                    } else {
-                        Modifier
-                    },
-                ),
-        style =
-            AppButtonStyle(
-                containerColor = backgroundColor,
-                contentColor = contentColor,
-                fontSize = dimensions.cardFontSize,
-                shape = cardShape,
-            ),
-    )
 }
 
 fun getColor(type: CardType): Color =

--- a/app/src/main/java/com/codenames/frontend/ui/screens/LobbyScreen.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/LobbyScreen.kt
@@ -102,7 +102,7 @@ fun LobbyScreen(
         val lobbyCode = lobbyUiState.lobbyCode.orEmpty()
         val teamAndRole = currentRole.toTeamAndRole()
 
-        if (connectionState == ConnectionState.CONNECTED) {
+        if (connectionState == ConnectionState.CONNECTED && lobbyUiState.isGameStarted) {
             navController.navigate(Screen.Gameboard.route)
 
             if (lobbyCode.isNotBlank() && teamAndRole != null) {

--- a/app/src/main/java/com/codenames/frontend/ui/screens/UserNameScreen.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/UserNameScreen.kt
@@ -35,6 +35,7 @@ import com.codenames.frontend.ui.roles.PlayerRoles
 import com.codenames.frontend.ui.theme.AppBackground
 import com.codenames.frontend.ui.theme.LocalResponsiveDimensions
 import com.codenames.frontend.ui.theme.blueGradient
+import com.codenames.frontend.viewmodel.ChatViewModel
 import com.codenames.frontend.viewmodel.GameViewModel
 import com.codenames.frontend.viewmodel.LobbyViewModel
 import com.codenames.frontend.viewmodel.SessionViewModel
@@ -46,6 +47,7 @@ fun UserNameScreen(
     viewModel: SessionViewModel,
     gameViewModel: GameViewModel,
     lobbyViewModel: LobbyViewModel,
+    chatViewModel: ChatViewModel
 ) {
     val userState by viewModel.userState.collectAsState()
     val rejoinState by viewModel.rejoinSessionState.collectAsState()
@@ -65,6 +67,7 @@ fun UserNameScreen(
             viewModel,
             gameViewModel,
             lobbyViewModel,
+            chatViewModel,
             RejoinUiState(
                 availableRejoinState = availableRejoinState,
                 connectionState = connectionState,
@@ -188,6 +191,7 @@ fun HandleRejoinEffects(
     viewModel: SessionViewModel,
     gameViewModel: GameViewModel,
     lobbyViewModel: LobbyViewModel,
+    chatViewModel: ChatViewModel,
     rejoinUiState: RejoinUiState,
 ) {
     val connectionState = rejoinUiState.connectionState
@@ -203,6 +207,14 @@ fun HandleRejoinEffects(
 
     LaunchedEffect(canRejoin) {
         if (!canRejoin) return@LaunchedEffect
+        if(availableRejoinState.sessionState.lobbyRole != null && availableRejoinState.sessionState.lobbyTeam != null) {
+            chatViewModel.subscribeToChats(
+                username,
+                lobbyCode,
+                availableRejoinState.sessionState.lobbyTeam.name,
+                availableRejoinState.sessionState.lobbyRole.name
+            )
+        }
 
         gameViewModel.rejoinGame(username, userId, availableRejoinState)
         lobbyViewModel.startUpdateAfterRejoin(lobbyCode)

--- a/app/src/main/java/com/codenames/frontend/ui/screens/UserNameScreen.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/screens/UserNameScreen.kt
@@ -47,7 +47,7 @@ fun UserNameScreen(
     viewModel: SessionViewModel,
     gameViewModel: GameViewModel,
     lobbyViewModel: LobbyViewModel,
-    chatViewModel: ChatViewModel
+    chatViewModel: ChatViewModel,
 ) {
     val userState by viewModel.userState.collectAsState()
     val rejoinState by viewModel.rejoinSessionState.collectAsState()
@@ -207,12 +207,12 @@ fun HandleRejoinEffects(
 
     LaunchedEffect(canRejoin) {
         if (!canRejoin) return@LaunchedEffect
-        if(availableRejoinState.sessionState.lobbyRole != null && availableRejoinState.sessionState.lobbyTeam != null) {
+        if (availableRejoinState.sessionState.lobbyRole != null && availableRejoinState.sessionState.lobbyTeam != null) {
             chatViewModel.subscribeToChats(
                 username,
                 lobbyCode,
                 availableRejoinState.sessionState.lobbyTeam.name,
-                availableRejoinState.sessionState.lobbyRole.name
+                availableRejoinState.sessionState.lobbyRole.name,
             )
         }
 

--- a/app/src/main/java/com/codenames/frontend/ui/theme/ResponsiveDimensions.kt
+++ b/app/src/main/java/com/codenames/frontend/ui/theme/ResponsiveDimensions.kt
@@ -15,6 +15,7 @@ data class ResponsiveDimensions(
     val sectionSpacing: Dp,
     val itemSpacing: Dp,
     val smallSpacing: Dp,
+    val largeSpacing: Dp,
     val cornerButtonSize: Dp,
     val returnButtonWidth: Dp,
     val primaryButtonWidth: Dp,
@@ -38,6 +39,7 @@ data class ResponsiveDimensions(
     val bodyFontSize: TextUnit,
     val smallFontSize: TextUnit,
     val cardFontSize: TextUnit,
+    val smallCardFontSize: TextUnit,
     val gameBoardTopSpacing: Dp,
 )
 
@@ -61,8 +63,9 @@ fun responsiveDimensionsFor(
         isNarrowWidth = isNarrowWidth,
         screenPadding = compactDp(isCompactHeight, compact = 10.dp, regular = 16.dp),
         sectionSpacing = compactDp(isCompactHeight, compact = 10.dp, regular = 16.dp),
-        itemSpacing = compactDp(isCompactHeight, compact = 6.dp, regular = 10.dp),
-        smallSpacing = 6.dp,
+        itemSpacing = compactDp(isCompactHeight, compact = 6.dp, regular = 12.dp),
+        smallSpacing = compactDp(isCompactHeight, compact = 6.dp, regular = 12.dp),
+        largeSpacing = compactDp(isCompactHeight, compact = 44.dp, regular = 52.dp),
         cornerButtonSize = compactDp(isCompactHeight, compact = 44.dp, regular = 52.dp),
         returnButtonWidth = narrowDp(isNarrowWidth, narrow = 112.dp, regular = 132.dp),
         primaryButtonWidth = (maxWidth * 0.22f).coerceIn(150.dp, 220.dp),
@@ -77,7 +80,7 @@ fun responsiveDimensionsFor(
         gameChatHeightFraction = compactFloat(isCompactHeight, compact = 0.86f, regular = 0.90f),
         gameStatusBarHeight = compactDp(isCompactHeight, compact = 24.dp, regular = 32.dp),
         gameHintCountWidth = compactDp(isCompactHeight, compact = 96.dp, regular = 112.dp),
-        gameHintInputHeight = compactDp(isCompactHeight, compact = 72.dp, regular = 80.dp),
+        gameHintInputHeight = compactDp(isCompactHeight, compact = 64.dp, regular = 72.dp),
         gameHintInputWeight = narrowFloat(isNarrowWidth, narrow = 0.50f, regular = 0.62f),
         gameHintSendButtonWidth = compactDp(isCompactHeight, compact = 96.dp, regular = 112.dp),
         buttonFontSize = compactSp(isCompactHeight, compact = 18, regular = 22),
@@ -86,6 +89,7 @@ fun responsiveDimensionsFor(
         bodyFontSize = compactSp(isCompactHeight, compact = 16, regular = 20),
         smallFontSize = compactSp(isCompactHeight, compact = 10, regular = 12),
         cardFontSize = compactSp(isCompactHeight, compact = 16, regular = 18),
+        smallCardFontSize = compactSp(isCompactHeight, compact = 12, regular = 16),
         gameBoardTopSpacing = compactDp(isCompactHeight, compact = 2.dp, regular = 4.dp),
     )
 }

--- a/app/src/main/java/com/codenames/frontend/viewmodel/GameViewModel.kt
+++ b/app/src/main/java/com/codenames/frontend/viewmodel/GameViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.codenames.frontend.data.error.ErrorMessageMapper
+import com.codenames.frontend.data.model.GameCard
 import com.codenames.frontend.data.model.GameState
 import com.codenames.frontend.data.model.RejoinState
 import com.codenames.frontend.data.model.enums.ConnectionState
@@ -38,6 +39,8 @@ class GameViewModel
 
         private val _connectionState = MutableStateFlow<ConnectionState>(ConnectionState.IDLE)
         val connectionState: StateFlow<ConnectionState> = _connectionState
+        private val _errorMessage = MutableStateFlow<String?>(null)
+        val errorMessage: StateFlow<String?> = _errorMessage
 
         fun connect(
             lobbyCode: String,
@@ -95,6 +98,10 @@ class GameViewModel
         ) {
             if (lobbyCode.isBlank() || team == null) {
                 return
+            }
+
+            if(!validateWord(word, uiState.value.cards)) {
+                setErrorState(IllegalArgumentException("The hint cannot contain any spaces or words on the board!"))
             }
 
             val turn = uiState.value.currentTurn
@@ -269,4 +276,22 @@ class GameViewModel
         private fun Team.isActiveSpymasterTurn(turn: PlayerRoles): Boolean =
             (this == Team.BLUE && turn == PlayerRoles.BLUE_SPYMASTER) ||
                 (this == Team.RED && turn == PlayerRoles.RED_SPYMASTER)
+
+        private fun validateWord(word: String, cards: List<GameCard>) : Boolean{
+            if(word.contains(" ")) return false
+            for(card in cards) {
+                if(card.word == word){
+                    return false
+                }
+            }
+            return true
+        }
+
+        fun clearErrorState() {
+            _errorMessage.value = null
+        }
+
+        private fun setErrorState(error: Throwable) {
+            _errorMessage.value = ErrorMessageMapper.toUserMessage(error)
+        }
     }

--- a/app/src/main/java/com/codenames/frontend/viewmodel/GameViewModel.kt
+++ b/app/src/main/java/com/codenames/frontend/viewmodel/GameViewModel.kt
@@ -100,7 +100,7 @@ class GameViewModel
                 return
             }
 
-            if(!validateWord(word, uiState.value.cards)) {
+            if (!validateWord(word, uiState.value.cards)) {
                 setErrorState(IllegalArgumentException("The hint cannot contain any spaces or words on the board!"))
             }
 
@@ -277,10 +277,13 @@ class GameViewModel
             (this == Team.BLUE && turn == PlayerRoles.BLUE_SPYMASTER) ||
                 (this == Team.RED && turn == PlayerRoles.RED_SPYMASTER)
 
-        private fun validateWord(word: String, cards: List<GameCard>) : Boolean{
-            if(word.contains(" ")) return false
-            for(card in cards) {
-                if(card.word == word){
+        private fun validateWord(
+            word: String,
+            cards: List<GameCard>,
+        ): Boolean {
+            if (word.contains(" ")) return false
+            for (card in cards) {
+                if (card.word == word) {
                     return false
                 }
             }

--- a/app/src/main/java/com/codenames/frontend/viewmodel/GameViewModel.kt
+++ b/app/src/main/java/com/codenames/frontend/viewmodel/GameViewModel.kt
@@ -277,7 +277,7 @@ class GameViewModel
             (this == Team.BLUE && turn == PlayerRoles.BLUE_SPYMASTER) ||
                 (this == Team.RED && turn == PlayerRoles.RED_SPYMASTER)
 
-        private fun validateWord(
+        fun validateWord(
             word: String,
             cards: List<GameCard>,
         ): Boolean {
@@ -294,7 +294,7 @@ class GameViewModel
             _errorMessage.value = null
         }
 
-        private fun setErrorState(error: Throwable) {
+        fun setErrorState(error: Throwable) {
             _errorMessage.value = ErrorMessageMapper.toUserMessage(error)
         }
     }

--- a/app/src/main/java/com/codenames/frontend/viewmodel/LobbyViewModel.kt
+++ b/app/src/main/java/com/codenames/frontend/viewmodel/LobbyViewModel.kt
@@ -260,14 +260,7 @@ class LobbyViewModel
 
         fun cleanup() {
             _state.update {
-                it.copy(
-                    lobbyCode = null,
-                    players = emptyList(),
-                    blueOperatives = emptyList(),
-                    blueSpymasters = emptyList(),
-                    redOperatives = emptyList(),
-                    redSpymasters = emptyList(),
-                )
+                LobbyUiState()
             }
             stopPolling()
             clearError()

--- a/app/src/test/java/com/codenames/frontend/viewmodel/GameViewModelTest.kt
+++ b/app/src/test/java/com/codenames/frontend/viewmodel/GameViewModelTest.kt
@@ -1,6 +1,8 @@
 package com.codenames.frontend.viewmodel
 
 import android.util.Log
+import com.codenames.frontend.data.error.ErrorMessageMapper
+import com.codenames.frontend.data.model.GameCard
 import com.codenames.frontend.data.model.GameState
 import com.codenames.frontend.data.model.RejoinState
 import com.codenames.frontend.data.model.SessionState
@@ -32,10 +34,12 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.util.UUID
+import kotlin.test.assertNull
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class GameViewModelTest {
@@ -781,4 +785,59 @@ class GameViewModelTest {
 
             assertTrue(viewModel.connectionState.value is ConnectionState.Error)
         }
+
+    @Test
+    fun validateWord_returnsFalse_whenWordContainsSpace() {
+        val cards = emptyList<GameCard>()
+
+        val result = viewModel.validateWord("hello world", cards)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun validateWord_returnsFalse_whenWordAlreadyExists() {
+        val cards =
+            listOf(
+                GameCard(word = "Apple", type = CardType.NEUTRAL),
+            )
+
+        val result = viewModel.validateWord("Apple", cards)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun validateWord_returnsTrue_whenWordIsValid() {
+        val cards =
+            listOf(
+                GameCard(word = "Apple", type = CardType.BLUE),
+                GameCard(word = "Tree", type = CardType.BLUE),
+            )
+
+        val result = viewModel.validateWord("House", cards)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun clearErrorState_setsErrorMessageToNull() {
+        viewModel.setErrorState(IllegalArgumentException("Some Error"))
+
+        viewModel.clearErrorState()
+
+        assertNull(viewModel.errorMessage.value)
+    }
+
+    @Test
+    fun setErrorState_mapsExceptionToUserMessage() {
+        val exception = IllegalArgumentException("Test")
+
+        viewModel.setErrorState(exception)
+
+        assertEquals(
+            ErrorMessageMapper.toUserMessage(exception),
+            viewModel.errorMessage.value,
+        )
+    }
 }


### PR DESCRIPTION
# Context
This PR fixes some bugs and UI issues. If you have any suggestions for further fixes, feel free to comment (so we don't need to review and approve as many PRs).

# Details
Changes include:
- fix for rejoin: I added the missing chat subcription after rejoin, cheating now works normally
- new send button: To make the hint section a bit nicer, I changed the send button to a send icon (also for sending chat messages). The hint section is also a bit smaller now, to avoid collisions with the android action bar. I could not fix any linebreaks here, because I could not recreate the issue (please test, if you own the mobile the issue occured on)
- fix for linebreaks on cards: I noticed that sometimes, the words are too long to fit in one line, so I changed the font size for longer words.
- some paddings adjusted.
- added error handling for invalid hints

# Changes in the Codebase
- new AppSendButton
- some new responsive Dimensions (e.g., smallCardFontSize)
- see above

# Changes outside the codebase
N/A

# Additional Info
N/A